### PR TITLE
chore: allow CI runs for PRs not targeted to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,6 @@ on:
       - "main"
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    branches: [ dev ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This helps development branches (e.g. plonk)