### PR TITLE
ci: Update `bump-version-PR.yml`

### DIFF
--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -48,12 +48,12 @@ jobs:
             VERSION=${{ inputs.version }}
             BASE_BRANCH="release/$BASE_VERSION_SHORT"
             PR_BRANCH="${{ inputs.type }}/${{ inputs.version }}"
-            git checkout ${{ env.PR_BRANCH }}
+            git checkout $PR_BRANCH
           else
             VERSION=$BASE_VERSION
             BASE_BRANCH="main"
             PR_BRANCH="release/$BASE_VERSION_SHORT"
-            git checkout -b ${{ env.PR_BRANCH }}
+            git checkout -b $PR_BRANCH
           fi
 
           echo "BASE_BRANCH=$BASE_BRANCH" | tee -a $GITHUB_ENV


### PR DESCRIPTION
- Gets the `aptos` workspace members programmatically per https://github.com/lurk-lab/sphinx/pull/48#discussion_r1646831971
  - Adds the `aptos/programs` crates manually since they aren't workspace members.
- Fixes a syntax error from https://github.com/lurk-lab/zk-light-clients/actions/runs/9619304150/job/26535131024