### PR TITLE
refactor: build on LC_PROGRAM_AUTOBUILD=1

### DIFF
--- a/aptos/README.md
+++ b/aptos/README.md
@@ -36,7 +36,7 @@ generated in two ways:
 
 - Automated: There is a build script located at `./aptos-programs/build.rs` that
   will compile all the programs and place them in the `./aptos-programs/artifacts`
-  folder.
+  folder. To enable this feature, it is needed to set the environment variable `LC_PROGRAM_AUTOBUILD=1`.
 - Manual: You can also compile the programs manually using `make` by running the following
   command in the `./aptos-programs` folder:
   ```shell

--- a/aptos/aptos-programs/build.rs
+++ b/aptos/aptos-programs/build.rs
@@ -10,6 +10,14 @@ const PROGRAM_PATTERNS: [&str; 2] = ["../programs/*", "../programs/benchmarks/*"
 const TARGET_DIR: [&str; 2] = ["./artifacts", "./artifacts/benchmarks"];
 
 fn main() {
+    // Get `LC_PROGRAM_AUTOBUILD` env variable, default to 0
+    let should_build: bool =
+        std::env::var("LC_PROGRAM_AUTOBUILD").unwrap_or_else(|_| "0".into()) == "1";
+
+    if !should_build {
+        return;
+    }
+
     // Re-run if the core library changes
     let core_dir = std::path::Path::new("../core");
     println!("cargo:rerun-if-changed={}", core_dir.display());


### PR DESCRIPTION
This PR makes the automated build of the program non-mandatory. Now, it has to be enabled with the  `LC_PROGRAM_AUTOBUILD=1` environment variable enabled.

We should find a better way to generate the program bytecode deterministically. Companion issue #40  