### PR TITLE
fix: action cron no year

### DIFF
--- a/.github/workflows/switch-license.yml
+++ b/.github/workflows/switch-license.yml
@@ -1,7 +1,7 @@
 name: License Switch April 23rd, 2025
 on:
   schedule:
-    - cron: '0 0 23 4 2025'
+    - cron: '0 0 23 4 *'
 
 jobs:
   release:


### PR DESCRIPTION
This PR sets a proper cron for the license switch action. There is no year specified, but is is alright as the created PR will delete the action file anyway.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule