### PR TITLE
docs: revamp doc for snark assets

### DIFF
--- a/aptos/docs/src/benchmark/configuration.md
+++ b/aptos/docs/src/benchmark/configuration.md
@@ -38,22 +38,7 @@ in [their dedicated section](../run/configuration.md).
 
 ## SNARK proofs
 
-When running any tests or benchmarks that makes Plonk proofs over BN254, it's necessary to build the correct circuit artifacts.
-
-If you don't manually build them, it will lead to a proof generation failure (unsatisfied constraint) due to
-circuit differences between SP1 and Sphinx.
-
-To enable Plonk proofs, we first need to generate the necessary circuit artifacts.
-
-We need to head to the Sphinx repository and run the build script:
-
-```bash
-cd sphinx/prover && \
-  make build-plonk-bn254 && \
-  mkdir -p ~/.sp1/circuits/plonk_bn254/e48c01ec/ && \
-  cp build/* ~/.sp1/circuits/plonk_bn254/e48c01ec/
-```
-
-The trailing commit identifier after `~/.sp1/circuits/plonk_bn254/` depends on the value of `PLONK_BN254_ARTIFACTS_COMMIT`
-defined [here](https://github.com/lurk-lab/sphinx/blob/dev/prover/src/install.rs),
-make sure to use the most up-to-date value for the specific Sphinx release.
+When running any tests or benchmarks that makes Plonk proofs over BN254, the prover leverages some pre-built circuits
+artifacts. Those circuits artifacts are generated when we release new versions of Sphinx and are made avaialble on a
+remote storage. The current address for the storage can be
+found [here](https://github.com/lurk-lab/sphinx/blob/dev/prover/src/install.rs).

--- a/aptos/docs/src/benchmark/e2e.md
+++ b/aptos/docs/src/benchmark/e2e.md
@@ -49,8 +49,7 @@ It measures two main metrics for each proof:
 
 ## SNARK proofs
 
-To benchmark the end-to-end flow with Plonk proofs over BN254, we first need to generate the circuits assets as described in [the
-configuration section](./configuration.md). Then, just pass the environment variable `SNARK=1`:
+To enable SNARK proving, just pass the environment variable `SNARK=1`:
 
 ```bash
 RUN_SERIAL=1 SNARK=1 RUST_LOG="debug" RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable" PRIMARY_ADDR="127.0.0.1:8080" SECONDARY_ADDR="127.0.0.1:8081" cargo +nightly bench --bench proof_server

--- a/aptos/docs/src/run/setup_proof_server.md
+++ b/aptos/docs/src/run/setup_proof_server.md
@@ -10,23 +10,11 @@ Make sure that the configuration specified in [the dedicated section](./configur
 
 ## SNARK proofs
 
-We mentioned earlier that the Proof Server has the capabilities of handling two types of proofs: either Sphinx core proofs
-or SNARK proofs using Plonk.
-
-To enable Plonk proofs, we first need to generate the necessary circuit artifacts.
-
-We need to head to the Sphinx repository and run the build script:
-
-```bash
-cd sphinx/prover && \
-  make build-plonk-bn254 && \
-  mkdir -p ~/.sp1/circuits/plonk_bn254/e48c01ec/ && \
-  cp build/* ~/.sp1/circuits/plonk_bn254/e48c01ec/
-```
-
-The trailing commit identifier after `~/.sp1/circuits/plonk_bn254/` depends on the value of `PLONK_BN254_ARTIFACTS_COMMIT`
-defined [here](https://github.com/lurk-lab/sphinx/blob/dev/prover/src/install.rs),
-make sure to use the most up-to-date value for the specific Sphinx release.
+We mentioned earlier that the Proof Server has the capabilities of handling two types of proofs: either Sphinx core
+proofs
+or SNARK proofs using Plonk. The circuit artifacts for the SNARK proofs are stored in a remote storage. The current
+address
+for the storage can be found [here](https://github.com/lurk-lab/sphinx/blob/dev/prover/src/install.rs).
 
 ## Environment variables
 


### PR DESCRIPTION
This PR revamps the doc regarding the SNARK assets. We do not need to generate them anymore!