### PR TITLE
chore: Fix CI references to main->dev

### DIFF
--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -51,7 +51,7 @@ jobs:
             git checkout $PR_BRANCH
           else
             VERSION=$BASE_VERSION
-            BASE_BRANCH="main"
+            BASE_BRANCH="dev"
             PR_BRANCH="release/$BASE_VERSION_SHORT"
             git checkout -b $PR_BRANCH
           fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
   push:
     branches:
-      - "main"
+      - "dev"
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 


### PR DESCRIPTION
The main CI workflow was not running on `dev` pushes.

The cycle-count-regression check was using the base branch as `main` and not `dev`.