### PR TITLE
ci: first version grep on bump

### DIFF
--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -85,7 +85,7 @@ jobs:
           
           bump_version() {
             cd "$1"
-            OLD_VERSION=$(grep -oP 'version = "\K[^"]+' Cargo.toml)
+            OLD_VERSION=$(grep -oP 'version = "\K[^"]+' Cargo.toml | head -n1)
             if [[ "${{ env.VERSION }}" > "$OLD_VERSION" ]]; then
               sed -i "s/version = \"$OLD_VERSION\"/version = \"${{ env.VERSION }}\"/" Cargo.toml
             else


### PR DESCRIPTION
This PR removes a trailing `/aptos` that is useless as the `working_dir` is already set in it.