### PR TITLE
ci: Update licenses

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Cargo-deny check
         run: |
           cargo deny --manifest-path ${{ matrix.package }}/Cargo.toml check
+      - name: Cargo-deny check programs
+        run: |
+          find ${{ matrix.package }}/programs -type d -name "target" -prune -o -type f -name "Cargo.toml" -exec cargo deny --manifest-path {} check \;
 
   solidity-unit-tests:
     needs: changes

--- a/.github/workflows/switch-license.yml
+++ b/.github/workflows/switch-license.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           cp .github/workflows/assets/APACHE.md aptos/LICENSE.md
 
+      - name: Replace Cargo.toml licenses
+        run: |
+          sed -i 's/license = "BUSL-1.1"/license = "Apache-2.0"/g' "aptos/Cargo.toml"
+          find aptos/programs -type d -name "target" -prune -o -type f -name "Cargo.toml" -exec sed -i 's/license = "BUSL-1.1"/license = "Apache-2.0"/g' {} \;
+
       - name: Replace SPDX license headers
         run: |
           find aptos -type f -exec sed -i 's|// SPDX-License-Identifier: BUSL-1.1|// SPDX-License-Identifier: Apache-2.0, MIT|g' {} \;
@@ -36,7 +41,7 @@ jobs:
         run: |
           {
             echo 'PR_BODY<<EOF'
-            This is an automated PR to update our licenses to Apache2.0.
+            This is an automated PR to update the Aptos licenses to Apache 2.0.
           
             [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             EOF

--- a/aptos/Cargo.toml
+++ b/aptos/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
+license = "BUSL-1.1"
 repository = "https://github.com/lurk-lab/zk-light-clients"
 
 [workspace.dependencies]

--- a/aptos/aptos-programs/Cargo.toml
+++ b/aptos/aptos-programs/Cargo.toml
@@ -3,7 +3,7 @@ name = "aptos-programs"
 version = "1.0.0"
 edition = { workspace = true }
 repository = { workspace = true }
-license = "BUSL-1.1"
+license = { workspace = true }
 
 [build-dependencies]
 glob = { workspace = true }

--- a/aptos/core/Cargo.toml
+++ b/aptos/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "aptos-lc-core"
 version = "1.0.0"
 edition = { workspace = true }
 repository = { workspace = true }
-license = "BUSL-1.1"
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/aptos/light-client/Cargo.toml
+++ b/aptos/light-client/Cargo.toml
@@ -3,7 +3,7 @@ name = "aptos-lc"
 version = "1.0.0"
 edition = { workspace = true }
 repository = { workspace = true }
-license = "BUSL-1.1"
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/aptos/programs/benchmarks/signature-verification/Cargo.toml
+++ b/aptos/programs/benchmarks/signature-verification/Cargo.toml
@@ -3,7 +3,7 @@
 version = "0.1.0"
 name = "signature-verification-program"
 edition = "2021"
-license-file = "../../LICENSE.md"
+license = "BUSL-1.1"
 
 [dependencies]
 aptos-lc-core = { path = "../../../core", package = "aptos-lc-core", default-features = false }

--- a/aptos/programs/epoch-change/Cargo.toml
+++ b/aptos/programs/epoch-change/Cargo.toml
@@ -3,7 +3,7 @@
 version = "1.0.0"
 name = "epoch-change-program"
 edition = "2021"
-license-file = "../../LICENSE.md"
+license = "BUSL-1.1"
 
 [dependencies]
 aptos-lc-core = { path = "../../core", package = "aptos-lc-core", default-features = false }

--- a/aptos/programs/inclusion/Cargo.toml
+++ b/aptos/programs/inclusion/Cargo.toml
@@ -3,7 +3,7 @@
 version = "1.0.0"
 name = "inclusion-program"
 edition = "2021"
-license-file = "../../LICENSE.md"
+license = "BUSL-1.1"
 
 [dependencies]
 aptos-lc-core = { path = "../../core", package = "aptos-lc-core", default-features = false }

--- a/aptos/proof-server/Cargo.toml
+++ b/aptos/proof-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proof-server"
 version = "1.0.0"
 edition = { workspace = true }
-license = "BUSL-1.1"
+license = { workspace = true }
 repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/aptos/solidity/fixture-generator/Cargo.toml
+++ b/aptos/solidity/fixture-generator/Cargo.toml
@@ -2,7 +2,7 @@
 version = "1.0.0"
 name = "fixture-generator"
 edition = { workspace = true }
-license = "BUSL-1.1"
+license = { workspace = true }
 repository = { workspace = true }
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -162,6 +162,9 @@ exceptions = [
     { allow = ["BUSL-1.1"], crate = "aptos-programs" },
     { allow = ["BUSL-1.1"], crate = "fixture-generator" },
     { allow = ["BUSL-1.1"], crate = "proof-server" },
+    { allow = ["BUSL-1.1"], crate = "signature-verification-program" },
+    { allow = ["BUSL-1.1"], crate = "epoch-change-program" },
+    { allow = ["BUSL-1.1"], crate = "inclusion-program" },
     # Remove as soon as https://github.com/aptos-labs/aptos-core/issues/13931 is fixed
     { allow = ["GPL-3.0"], crate = "number_range"},
 ]

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -3,6 +3,11 @@ resolver = "2"
 
 members = ["core", "ethereum-programs", "light-client"]
 
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/lurk-lab/zk-light-clients"
+
 [workspace.dependencies]
 anyhow = "1.0.86"
 clap = "4.5.8"

--- a/ethereum/core/Cargo.toml
+++ b/ethereum/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ethereum-lc-core"
 version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+edition = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 homepage = "https://github.com/wormhole-foundation/example-zk-light-clients"
-repository = "https://github.com/wormhole-foundation/example-zk-light-clients"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/ethereum/ethereum-programs/Cargo.toml
+++ b/ethereum/ethereum-programs/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "ethereum-programs"
 version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+edition = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [build-dependencies]
 glob = { workspace = true }

--- a/ethereum/light-client/Cargo.toml
+++ b/ethereum/light-client/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "ethereum-lc"
 version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+edition = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
- Switches to workspace licenses
- Updates the `switch-license.yml` workflow to update the `Cargo.toml` license fields
- Runs `cargo deny` on the `programs` crates in `aptos` and `ethereum` in CI

Fixes #84 