### PR TITLE
ci: Run Move tests

### DIFF
--- a/aptos/Cargo.toml
+++ b/aptos/Cargo.toml
@@ -1,4 +1,3 @@
-# Test
 [workspace]
 resolver = "2"
 

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -1,4 +1,3 @@
-# Test
 [workspace]
 resolver = "2"
 


### PR DESCRIPTION
Runs Move tests in CI when the `ethereum` crate is modified by a PR.

Partially addresses the CI portion of #80. The remaining TODO is nightly fixture regeneration for Solidity and Move.

Successful run: https://github.com/lurk-lab/zk-light-clients/actions/runs/9863206518