### PR TITLE
ci: Add fixture PR reviewers

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -65,6 +65,7 @@ jobs:
           title: "chore: Update fixtures"
           commit-message: "chore: Update fixtures"
           labels: "automated-issue"
+          reviewers: "tchataigner, storojs72, wwared, huitseeker, samuelburnham"
           body: |
             This is an automated PR updating the proof fixtures for Solidity and Move (TBD), which are used for smart contract verification tests.
 


### PR DESCRIPTION
The fixture regeneration workflow introduced in #92 doesn't request any reviewers, so it has a tendency to sit unreviewed for a few days. This PR requests review from multiple maintainers to ensure we are properly notified.