### PR TITLE
ci: Update Rust version biweekly

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -2,9 +2,6 @@
 name: Rust Version Check
 
 on:
-  push:
-    branches:
-      - "ci-rust-version"
   workflow_dispatch:
   schedule:
     - cron:  '0 0 1,15 * *'
@@ -42,10 +39,10 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           branch: "ci-update-rust-version-${{ matrix.package }}"
-          title: "chore: Update `${{ matrix.package }}` Rust version to nightly-${{ env.RUST_VERSION }}"
-          commit-message: "chore: Update `${{ matrix.package }}` Rust version to nightly-${{ env.RUST_VERSION }}"
+          title: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"
+          commit-message: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"
           labels: "automated-issue"
-          #reviewers: "tchataigner, wwared, storojs72, huitseeker, samuelburnham"
+          reviewers: "tchataigner, wwared, storojs72, huitseeker, samuelburnham"
           body: |
             This is an automated PR updating the `${{ matrix.package }}` Rust version from `nightly-${{ env.TOOLCHAIN_VERSION }}` to `nightly-${{ env.RUST_VERSION }}`
 


### PR DESCRIPTION
Updates the Rust version for each of `aptos` and `ethereum` in separate PRs, which enables separate decision-making and only runs CI on the respective workspace.

Closes #106 

Successful runs: #108, #109

TODO:
- Open issue to reusify as a composite action rather than a reusable workflow, as it requires some configuration (stable vs. nightly, crate workspaces, etc.)