### PR TITLE
refactor: Refactor Ethereum light-client to reduce clone usage

### DIFF
--- a/ethereum/light-client/benches/committee_change.rs
+++ b/ethereum/light-client/benches/committee_change.rs
@@ -87,10 +87,7 @@ fn main() {
         .unwrap();
 
     // Prove committee change
-    let inputs = CommitteeChangeIn::new(
-        benchmark_assets.store.clone(),
-        benchmark_assets.update_new_period.clone(),
-    );
+    let inputs = CommitteeChangeIn::new(benchmark_assets.store, benchmark_assets.update_new_period);
 
     let start_proving = Instant::now();
     let proof = benchmark_assets

--- a/ethereum/light-client/benches/inclusion.rs
+++ b/ethereum/light-client/benches/inclusion.rs
@@ -95,9 +95,9 @@ fn main() {
 
     // Prove storage inclusion
     let inputs = StorageInclusionIn::new(
-        benchmark_assets.store.clone(),
-        benchmark_assets.finality_update.clone().into(),
-        benchmark_assets.eip1186_proof.clone(),
+        benchmark_assets.store,
+        benchmark_assets.finality_update.into(),
+        benchmark_assets.eip1186_proof,
     );
 
     let start_proving = Instant::now();

--- a/ethereum/light-client/src/bin/server_primary.rs
+++ b/ethereum/light-client/src/bin/server_primary.rs
@@ -53,8 +53,8 @@ async fn main() -> Result<()> {
                     Request::ProveCommitteeChange(boxed) => {
                         info!("Start proving");
                         let proof_handle = spawn_blocking(move || {
-                            let (proving_mode, inputs) = boxed.as_ref();
-                            committee_prover.prove(inputs.clone(), proving_mode.clone())
+                            let (proving_mode, inputs) = *boxed;
+                            committee_prover.prove(inputs, proving_mode)
                         });
                         let proof = proof_handle.await??;
                         info!("Proof generated. Serializing");

--- a/ethereum/light-client/src/bin/server_secondary.rs
+++ b/ethereum/light-client/src/bin/server_secondary.rs
@@ -48,8 +48,8 @@ async fn main() -> Result<()> {
                     Request::ProveInclusion(boxed) => {
                         info!("Start proving");
                         let proof_handle = spawn_blocking(move || {
-                            let (proving_mode, inputs) = boxed.as_ref();
-                            inclusion_prover.prove(inputs.clone(), proving_mode.clone())
+                            let (proving_mode, inputs) = *boxed;
+                            inclusion_prover.prove(inputs, proving_mode)
                         });
                         let proof = proof_handle.await??;
                         info!("Proof generated. Serializing");

--- a/ethereum/light-client/src/client/mod.rs
+++ b/ethereum/light-client/src/client/mod.rs
@@ -156,8 +156,8 @@ impl Client {
     pub async fn prove_committee_change(
         &self,
         proving_mode: ProvingMode,
-        store: &LightClientStore,
-        update: &Update,
+        store: LightClientStore,
+        update: Update,
     ) -> Result<ProofType, ClientError> {
         self.proof_server_client
             .prove_committee_change(proving_mode, store, update)
@@ -228,9 +228,9 @@ impl Client {
     pub async fn prove_storage_inclusion(
         &self,
         proving_mode: ProvingMode,
-        store: &LightClientStore,
-        update: &Update,
-        eip1186_proof: &EIP1186Proof,
+        store: LightClientStore,
+        update: Update,
+        eip1186_proof: EIP1186Proof,
     ) -> Result<ProofType, ClientError> {
         self.proof_server_client
             .prove_storage_inclusion(proving_mode, store, update, eip1186_proof)

--- a/ethereum/light-client/src/client/proof_server.rs
+++ b/ethereum/light-client/src/client/proof_server.rs
@@ -55,8 +55,8 @@ impl ProofServerClient {
     pub(crate) async fn prove_committee_change(
         &self,
         proving_mode: ProvingMode,
-        store: &LightClientStore,
-        update: &Update,
+        store: LightClientStore,
+        update: Update,
     ) -> Result<ProofType, ClientError> {
         let mut stream =
             TcpStream::connect(&self.address)
@@ -65,7 +65,7 @@ impl ProofServerClient {
                     endpoint: "ProofServer::ProveCommitteeChange".into(),
                     source: err.into(),
                 })?;
-        let inputs = CommitteeChangeIn::new(store.clone(), update.clone());
+        let inputs = CommitteeChangeIn::new(store, update);
         let request = Request::ProveCommitteeChange(Box::new((proving_mode, inputs)));
 
         write_bytes(
@@ -163,9 +163,9 @@ impl ProofServerClient {
     pub(crate) async fn prove_storage_inclusion(
         &self,
         proving_mode: ProvingMode,
-        store: &LightClientStore,
-        update: &Update,
-        eip1186_proof: &EIP1186Proof,
+        store: LightClientStore,
+        update: Update,
+        eip1186_proof: EIP1186Proof,
     ) -> Result<ProofType, ClientError> {
         let mut stream =
             TcpStream::connect(&self.address)
@@ -174,7 +174,7 @@ impl ProofServerClient {
                     endpoint: "ProofServer::ProveInclusion".into(),
                     source: err.into(),
                 })?;
-        let inputs = StorageInclusionIn::new(store.clone(), update.clone(), eip1186_proof.clone());
+        let inputs = StorageInclusionIn::new(store, update, eip1186_proof);
         let request = Request::ProveInclusion(Box::new((proving_mode, inputs)));
 
         write_bytes(

--- a/ethereum/light-client/src/proofs/committee_change.rs
+++ b/ethereum/light-client/src/proofs/committee_change.rs
@@ -57,7 +57,7 @@ impl CommitteeChangeProver {
 }
 
 /// The input for the sync committee change proof.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CommitteeChangeIn {
     store: LightClientStore,
     update: Update,

--- a/ethereum/light-client/src/proofs/inclusion.rs
+++ b/ethereum/light-client/src/proofs/inclusion.rs
@@ -59,7 +59,7 @@ impl StorageInclusionProver {
 }
 
 /// The input for the storage inclusion proof.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StorageInclusionIn {
     store: LightClientStore,
     update: Update,

--- a/ethereum/light-client/src/proofs/mod.rs
+++ b/ethereum/light-client/src/proofs/mod.rs
@@ -31,7 +31,7 @@ pub mod error;
 pub mod inclusion;
 
 /// The proving mode for the prover.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ProvingMode {
     STARK,
     SNARK,

--- a/ethereum/light-client/src/test_utils.rs
+++ b/ethereum/light-client/src/test_utils.rs
@@ -72,9 +72,9 @@ pub fn generate_committee_change_test_assets() -> CommitteeChangeTestAssets {
 #[derive(Getters)]
 #[getset(get = "pub")]
 pub struct InclusionTestAssets {
-    store: LightClientStore,
-    finality_update: FinalityUpdate,
-    eip1186_proof: EIP1186Proof,
+    pub store: LightClientStore,
+    pub finality_update: FinalityUpdate,
+    pub eip1186_proof: EIP1186Proof,
 }
 
 pub fn generate_inclusion_test_assets() -> InclusionTestAssets {

--- a/ethereum/light-client/src/types/beacon/update.rs
+++ b/ethereum/light-client/src/types/beacon/update.rs
@@ -9,10 +9,10 @@ use ethereum_lc_core::types::ForkDigest;
 use getset::Getters;
 
 /// Payload received from the Beacon Node when fetching updates starting at a given period.
-#[derive(Debug, Clone, Getters)]
+#[derive(Debug, Getters)]
 #[getset(get = "pub")]
 pub struct UpdateResponse {
-    updates: Vec<UpdateItem>,
+    pub updates: Vec<UpdateItem>,
 }
 
 impl UpdateResponse {
@@ -73,12 +73,12 @@ impl UpdateResponse {
     /// # Returns
     ///
     /// An `Option` containing the update if it exists.
-    pub fn contains_committee_change(&self, known_period: u64) -> Result<Option<Update>> {
-        for update_item in &self.updates {
+    pub fn extract_committee_change(self, known_period: u64) -> Result<Option<Update>> {
+        for update_item in self.updates {
             let update_period =
                 calc_sync_period(update_item.update.attested_header().beacon().slot());
             if update_period == known_period + 1 {
-                return Ok(Some(update_item.update.clone()));
+                return Ok(Some(update_item.update));
             }
         }
         Ok(None)
@@ -86,10 +86,10 @@ impl UpdateResponse {
 }
 
 /// An item in the `UpdateResponse` containing the size of the update, the fork digest and the update itself.
-#[derive(Debug, Clone, Getters)]
+#[derive(Debug, Getters)]
 #[getset(get = "pub")]
 pub struct UpdateItem {
-    size: u64,
-    fork_digest: ForkDigest,
-    update: Update,
+    pub size: u64,
+    pub fork_digest: ForkDigest,
+    pub update: Update,
 }

--- a/ethereum/light-client/src/types/network.rs
+++ b/ethereum/light-client/src/types/network.rs
@@ -3,7 +3,7 @@ use crate::proofs::inclusion::StorageInclusionIn;
 use crate::proofs::{ProofType, ProvingMode};
 use anyhow::{anyhow, Error};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Request {
     /// Request to prove the validity of a sync committee change.
     ProveCommitteeChange(Box<(ProvingMode, CommitteeChangeIn)>),

--- a/ethereum/programs/inclusion/src/main.rs
+++ b/ethereum/programs/inclusion/src/main.rs
@@ -64,9 +64,9 @@ pub fn main() {
     let update_sig_period = calc_sync_period(update.signature_slot());
     let store_period = calc_sync_period(store.finalized_header().beacon().slot());
     let sync_committee = if update_sig_period == store_period {
-        store.current_sync_committee().clone()
+        store.current_sync_committee
     } else {
-        store.next_sync_committee().clone().unwrap()
+        store.next_sync_committee().unwrap()
     };
     let sync_committee_hash = keccak256_hash(&sync_committee.to_ssz_bytes())
         .expect("LightClientStore::current_sync_committee: could not hash committee after inclusion proving");

--- a/fixture-generator/src/bin/main.rs
+++ b/fixture-generator/src/bin/main.rs
@@ -90,9 +90,9 @@ fn generate_fixture_inclusion_ethereum_lc() {
     let prover = StorageInclusionProver::new();
     let test_assets = generate_inclusion_test_assets();
     let input = StorageInclusionIn::new(
-        test_assets.store().clone(),
-        test_assets.finality_update().clone().into(),
-        test_assets.eip1186_proof().clone(),
+        test_assets.store,
+        test_assets.finality_update.into(),
+        test_assets.eip1186_proof,
     );
     let proof = match prover.prove(input, ProvingMode::SNARK).unwrap() {
         ProofType::SNARK(inner_proof) => inner_proof,
@@ -186,8 +186,8 @@ fn generate_fixture_epoch_change_ethereum_lc() {
         .process_light_client_update(&test_assets.update)
         .unwrap();
     let new_period_inputs = CommitteeChangeIn::new(
-        test_assets.store.clone(),
-        test_assets.update_new_period.clone(),
+        test_assets.store,
+        test_assets.update_new_period,
     );
     let prover = CommitteeChangeProver::new();
     let proof = match prover.prove(new_period_inputs, ProvingMode::SNARK).unwrap() {


### PR DESCRIPTION
Minor refactorings while reviewing

## In details
- Refactored handling for `ProveInclusion` and `ProveCommitteeChange` requests across multiple files, emphasizing direct use of variables instead of relying on cloning.
- Removed the `Clone` trait derivation in several structs including `CommitteeChangeIn`, `StorageInclusionIn`, and `UpdateResponse`, among others.
- Added the `Copy` trait to the `ProvingMode` enum for efficient handling of small-sized data.
- Adjusted function arguments in the `Client` struct, shifting from references to owned types,
- Changed the access modifier of `store`, `finality_update`, and `eip1186_proof` from private to public, and made fields of `UpdateResponse` and `UpdateItem` public.