### PR TITLE
feat: PAT for PR creation + better release changelog

### DIFF
--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -143,4 +143,4 @@ jobs:
 
           gh pr create --title "${{ env.PR_DESCRIPTION }}" --body-file ./body.md --head ${{ env.PR_BRANCH }} --base ${{ env.BASE_BRANCH }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -4,14 +4,14 @@ name: Rust Version Check
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 0 1,15 * *'
+    - cron: '0 0 1,15 * *'
 
 jobs:
   rust-version-check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: ["aptos", "ethereum"]
+        package: [ "aptos", "ethereum" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -38,6 +38,7 @@ jobs:
         if: steps.compare-versions.outputs.outdated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.REPO_TOKEN }}
           branch: "ci-update-rust-version-${{ matrix.package }}"
           title: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"
           commit-message: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -34,20 +34,50 @@ jobs:
         run: |
           VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2)
           RELEASE_BRANCH="${{ startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.head.ref || github.event.pull_request.base.ref }}"
+          PATH=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2 | cut -d'.' -f 1)
 
           if [[ "${{ startsWith(github.event.pull_request.head.ref, 'release/') }}" == "true" ]]; then
             VERSION="${VERSION}.0"
           fi
 
           git tag -a $VERSION -m "$VERSION" origin/$RELEASE_BRANCH
-          git push origin $VERSION --follow-tags
+          git push origin $VERSION --follow-tags          
+          echo "path=$PATH" | tee -a "$GITHUB_OUTPUT"
           echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
           echo "RELEASE_BRANCH=$RELEASE_BRANCH" | tee -a "$GITHUB_ENV"
+
+
+      - name: Get latest release reference
+        id: get-latest-release
+        run: |
+          if [[ "${{ startsWith(github.event.pull_request.head.ref, 'release/') }}" == "true" ]]; then
+            REGEX=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2 | cut -d'.' -f 1)
+            LATEST_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 100 | grep -Ei "$REGEX" | head -n 1)
+
+            if [ -z "$LATEST_RELEASE" ]; then
+              FIRST_COMMIT=$(git rev-list --max-parents=0 dev#refs/heads/)
+
+              echo "The first commit on branch dev is $FIRST_COMMIT"
+              echo "latest_release=$FIRST_COMMIT" | tee -a "$GITHUB_OUTPUT"      
+            else
+              echo "Found release: $LATEST_RELEASE"
+              echo "latest_release=$LATEST_RELEASE" | tee -a "$GITHUB_OUTPUT"      
+            fi
+
+          else
+            REGEX=$(echo "${{ github.event.pull_request.base.ref }}" | cut -d'/' -f 2)
+            LATEST_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 100 | grep -Ei "$REGEX" | head -n 1)
+
+            echo "Found release: $LATEST_RELEASE"
+            echo "latest_release=$LATEST_RELEASE" | tee -a "$GITHUB_OUTPUT"
+          fi
 
       - name: Build Changelog
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v4
         with:
+          path: "./${{ steps.get-version.outputs.path }}"
+          fromTag: ${{ steps.get-latest-release.outputs.latest_release }}
           toTag: ${{ steps.get-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR changes the PR creation flow to use a PAT, this will alow us to trigger CI on automated PRs. It also changes the way we generate changelog for releases:
- On release: Look for latest major or minor release for the given light client and compile changes since then.
- On new Light Client release: Compile the changes solely on the folder that is allocated to this light client
- On hotfix: Compiles the changes since the latest patch of the version

