### PR TITLE
ci: Add Ethereum tests to `cycle-count-regression` check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,13 +204,11 @@ jobs:
       - name: Set env
         run: |
           if [[ "${{ matrix.package }}" == "aptos" ]]; then
-            # TODO: Remove hardcoded test names
             TESTS="test_execute_inclusion test_execute_epoch_change test_execute_sig"
             FEATURES="--features aptos"
           elif [[ "${{ matrix.package }}" == "ethereum" ]]; then
-            # TODO: Add execution tests
-            TESTS=""
-            FEATURES=""
+            TESTS="test_execute_inclusion test_execute_committee_change"
+            FEATURES="--features ethereum"
           fi
           echo "TESTS=$TESTS" | tee -a $GITHUB_ENV
           echo "FEATURES=$FEATURES" | tee -a $GITHUB_ENV

--- a/ethereum/light-client/src/proofs/inclusion.rs
+++ b/ethereum/light-client/src/proofs/inclusion.rs
@@ -299,7 +299,6 @@ mod test {
     use crate::test_utils::generate_inclusion_test_assets;
     use ethereum_lc_core::crypto::hash::keccak256_hash;
 
-    // Test CI
     #[test]
     fn test_execute_inclusion() {
         let test_assets = generate_inclusion_test_assets();

--- a/ethereum/light-client/src/proofs/inclusion.rs
+++ b/ethereum/light-client/src/proofs/inclusion.rs
@@ -299,6 +299,7 @@ mod test {
     use crate::test_utils::generate_inclusion_test_assets;
     use ethereum_lc_core::crypto::hash::keccak256_hash;
 
+    // Test CI
     #[test]
     fn test_execute_inclusion() {
         let test_assets = generate_inclusion_test_assets();


### PR DESCRIPTION
Fixes the `cycle-count-regression` check for Ethereum, as the tests weren't being run.

Successful run: https://github.com/argumentcomputer/zk-light-clients/actions/runs/10413737228