### PR TITLE
ci: Switch to GH App token

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -76,10 +76,15 @@ jobs:
           path: ${{ github.workspace }}/${{ env.MOVE_FIXTURE_PATH }}
           pattern: "move_*"
           merge-multiple: true
+      - uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: "${{ secrets.REPO_TOKEN }}"
+          token: ${{ steps.generate-token.outputs.token }}
           branch: "ci-update-fixtures"
           title: "chore: Update fixtures"
           commit-message: "chore: Update fixtures"

--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -33,12 +33,18 @@ jobs:
         run: |
           sed -i 's/channel = .*/channel = "nightly-${{ env.RUST_VERSION }}"/' rust-toolchain.toml
         working-directory: ${{ github.workspace }}/${{ matrix.package }}
+      - uses: tibdex/github-app-token@v2
+        if: steps.compare-versions.outputs.outdated == 'true'
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       # Open PR if Rust version is out of date with latest nightly
       - name: Create Pull Request
         if: steps.compare-versions.outputs.outdated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.REPO_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           branch: "ci-update-rust-version-${{ matrix.package }}"
           title: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"
           commit-message: "chore: Update `${{ matrix.package }}` Rust version to `nightly-${{ env.RUST_VERSION }}`"


### PR DESCRIPTION
Switches to a GitHub App-generated token instead of a PAT when opening an automated PR via `peter-evans/create-pull-request`, per the docs ([1](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs),[2](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens)).

The default action behavior is to create a PR using the `github-actions` bot (e.g. https://github.com/argumentcomputer/zk-light-clients/pull/133). However, this has the limitation of not triggering CI, as the default `GITHUB_TOKEN` doesn't have permissions to trigger other workflows.

To work around this, we switched to a PAT. However, this changes the PR author to the owner of the PAT, which means that the author isn't allowed to review their own PR.

This PR thus switches to an ephemeral GitHub App token created by the `argument-ci-bot` app, which is scoped to the https://github.com/argumentcomputer org and specific repositories for security.

Successful run: https://github.com/argumentcomputer/zk-light-clients/pull/172