### PR TITLE
fix: Use `Box::pin` for large futures in ethereum's client binary

### DIFF
--- a/aptos/.cargo/config.toml
+++ b/aptos/.cargo/config.toml
@@ -20,6 +20,7 @@ xclippy = [
     "-Wclippy::implicit_clone",
     "-Wclippy::inefficient_to_string",
     "-Wclippy::invalid_upcast_comparisons",
+    "-Wclippy::large_futures",
     "-Wclippy::large_stack_arrays",
     "-Wclippy::large_types_passed_by_value",
     "-Wclippy::macro_use_imports",

--- a/ethereum/.cargo/config.toml
+++ b/ethereum/.cargo/config.toml
@@ -21,6 +21,7 @@ xclippy = [
     "-Wclippy::implicit_clone",
     "-Wclippy::inefficient_to_string",
     "-Wclippy::invalid_upcast_comparisons",
+    "-Wclippy::large_futures",
     "-Wclippy::large_stack_arrays",
     "-Wclippy::large_types_passed_by_value",
     "-Wclippy::macro_use_imports",

--- a/ethereum/light-client/src/client/mod.rs
+++ b/ethereum/light-client/src/client/mod.rs
@@ -159,9 +159,11 @@ impl Client {
         store: LightClientStore,
         update: Update,
     ) -> Result<ProofType, ClientError> {
-        self.proof_server_client
-            .prove_committee_change(proving_mode, store, update)
-            .await
+        Box::pin(
+            self.proof_server_client
+                .prove_committee_change(proving_mode, store, update),
+        )
+        .await
     }
 
     /// `verify_committee_change` makes a request to the Proof Server API to verify the proof of a committee change.
@@ -232,9 +234,13 @@ impl Client {
         update: Update,
         eip1186_proof: EIP1186Proof,
     ) -> Result<ProofType, ClientError> {
-        self.proof_server_client
-            .prove_storage_inclusion(proving_mode, store, update, eip1186_proof)
-            .await
+        Box::pin(self.proof_server_client.prove_storage_inclusion(
+            proving_mode,
+            store,
+            update,
+            eip1186_proof,
+        ))
+        .await
     }
 
     /// `verify_storage_inclusion` makes a request to the Proof Server API to verify the proof of a storage inclusion.

--- a/fixture-generator/.cargo/config.toml
+++ b/fixture-generator/.cargo/config.toml
@@ -20,6 +20,7 @@ xclippy = [
     "-Wclippy::implicit_clone",
     "-Wclippy::inefficient_to_string",
     "-Wclippy::invalid_upcast_comparisons",
+    "-Wclippy::large_futures",
     "-Wclippy::large_stack_arrays",
     "-Wclippy::large_types_passed_by_value",
     "-Wclippy::macro_use_imports",


### PR DESCRIPTION
This PR fixes the segfault introduced in #123 by:

* Turning on the `large_futures` clippy lint
* Fixing the lints by using `Box::pin`

The issue was that the stack-allocated futures were too large, leading to an allocation failure and segfault. Using `Box::pin` makes the future be heap allocated, which is another layer of indirection, but now the on-stack futures are not so large anymore.

Supersedes #174