### PR TITLE
ci: Update release workflow

### DIFF
--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -1,3 +1,11 @@
+# Workflow to create a new release PR, which does the following:
+#
+# - Pushes a new `release/<light-client>-v<version>` branch based on latest `dev`
+# - Creates a new branch from the release, then bumps the version with the `version` input
+# - Opens a PR from the `version-bump` branch to the release branch
+# - When merged, triggers a release from `tag-release.yml`
+#
+# The `version-bump` branch can then be safely deleted, while the release branch will be protected
 name: Bump Version
 on:
   workflow_dispatch:
@@ -31,11 +39,13 @@ jobs:
     steps:
       - name: Git config
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "argument-ci[bot]"
+          git config --global user.email "argument-ci[bot]@users.noreply.github.com"
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -45,29 +55,50 @@ jobs:
       - name: Install `tq-rs`
         run: cargo install tq-rs
 
-      # The `release/<aptos|ethereum|kadena>-v1.0` branch is always truncated, so that patch version merges still are valid Semver
-      # However, when we make the initial `release/<aptos|ethereum|kadena>-v1.0` version bump, we include the full `1.0.0` in `Cargo.toml`
-      # and the release for clarity
-      - name: Set branches
+      - uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+
+      # The `release/<aptos|ethereum|kadena>-v1.0` branch is always truncated, as we don't want to change
+      # the release branch name for patch versions
+      #
+      # However, when we make e.g. a `release/<aptos|ethereum|kadena>-v1.0` version bump, we include the full
+      # `1.0.0` in `Cargo.toml` and the release for clarity
+      - name: Create release branch
         run: |
+          BASE_VERSION="${{ inputs.version }}.0"
           BASE_VERSION_SHORT=$(echo "${{ inputs.version }}" | cut -d'.' -f1-2)
-          BASE_VERSION="${BASE_VERSION_SHORT}.0"
-          if [[ "${{ inputs.type }}" == "hotfix" ]]; then
-            VERSION=${{ inputs.version }}
-            BASE_BRANCH="release/${{ inputs.light-client }}-v$BASE_VERSION_SHORT"
-            PR_BRANCH="${{ inputs.type }}/${{ inputs.light-client }}-v${{ inputs.version }}"
-            git checkout -b $PR_BRANCH
+          BASE_BRANCH="release/${{ inputs.light-client }}-v$BASE_VERSION_SHORT"
+
+          if [[ "${{ inputs.type }}" == "release" ]]; then
+            git checkout -b $BASE_BRANCH
+            git push origin $BASE_BRANCH
           else
-            VERSION=$BASE_VERSION
-            BASE_BRANCH="dev"
-            PR_BRANCH="release/${{ inputs.light-client }}-v$BASE_VERSION_SHORT"
-            git checkout -b $PR_BRANCH
+            git checkout $BASE_BRANCH
           fi
 
+          echo "BASE_VERSION=$BASE_VERSION" | tee -a $GITHUB_ENV
           echo "BASE_BRANCH=$BASE_BRANCH" | tee -a $GITHUB_ENV
-          echo "PR_BRANCH=$PR_BRANCH" | tee -a $GITHUB_ENV
-          echo "PR_DESCRIPTION=chore(${{ inputs.light-client }}): Release $VERSION" | tee -a $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create PR branch
+        run: |
+          if [[ "${{ inputs.type }}" == "hotfix" ]]; then
+            VERSION=${{ inputs.version }
+            PR_BRANCH="${{ inputs.type }}/${{ inputs.light-client }}-v${{ inputs.version }}"
+          else
+            VERSION=$BASE_VERSION
+            PR_BRANCH="version-bump"
+          git checkout -b $PR_BRANCH
+
           echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
+          echo "PR_BRANCH=$PR_BRANCH" | tee -a $GITHUB_ENV
+          echo "PR_TITLE=chore(${{ inputs.light-client }}): Release $VERSION" | tee -a $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       # Regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
       - name: Validate version
@@ -91,7 +122,7 @@ jobs:
             members=$(tq workspace.members -f Cargo.toml | jq -r '. += ["programs/inclusion", "programs/committee-change"] | .[]')
           elif [[ "${{ inputs.light-client }}" == "aptos" ]]; then
             members=$(tq workspace.members -f Cargo.toml | jq -r '. += ["programs/inclusion", "programs/epoch-change"] | .[]')
-          elif [[ "${{ inputs.light-client }}" == "aptos" ]]; then
+          elif [[ "${{ inputs.light-client }}" == "kadena" ]]; then
             members=$(tq workspace.members -f Cargo.toml | jq -r '. += [""] | .[]')
           else
             echo "Unknown light-client: ${{ inputs.light-client }}. Aborting..."
@@ -126,21 +157,24 @@ jobs:
       - name: Commit changes
         run: |
           git add .
-          git commit -m "${{ env.PR_DESCRIPTION }}"
+          git commit -m "${{ env.PR_TITLE }}"
           git push origin ${{ env.PR_BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       # Note: Can't use `peter-evans/create-pull-request` because for hotfixes we need to make the PR with an existing branch
       # The former always creates a new one for single-commit PRs, thus overwriting the actual hotfix
-      - name: Create PR
+      - name: Create pull request
         run: |
           cat << 'EOF' > body.md
           This is an automated release PR for version `${{ env.VERSION }}` of the ${{ inputs.light-client }} light client.
+
+          Please update the Sphinx dependency versions to the appropriate release tag manually. (TODO: Automate)
 
           On merge, this will trigger the [release publish workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/tag-release.yml), which will upload a new GitHub release with tag `${{ inputs.light-client }}-v${{ env.VERSION }}`.
 
           [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           EOF
-
-          gh pr create --title "${{ env.PR_DESCRIPTION }}" --body-file ./body.md --head ${{ env.PR_BRANCH }} --base ${{ env.BASE_BRANCH }}
+          gh pr create --title "${{ env.PR_TITLE }}" --body-file ./body.md --head ${{ env.PR_BRANCH }} --base ${{ env.BASE_BRANCH }}
         env:
-          GH_TOKEN: ${{ secrets.REPO_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,10 @@ jobs:
         id: get-packages
         run: |
           PACKAGES=$(echo '${{ steps.filter.outputs.changes }}' | jq -c '.')
+          # Remove `fixture-generator` if it exists, as we don't want to run tests or the cycle checker
           LC_PACKAGES=$(echo "$PACKAGES" | jq -c 'del(.[] | select(. == "fixture-generator"))')
 
+          # If any packages were changed, ensure we run clippy on `fixture-generator` as it imports all light clients
           if [ "$PACKAGES" != "[]" ]; then
             if ! echo "$PACKAGES" | jq -e '.[] | select(. == "fixture-generator")' > /dev/null; then
               PACKAGES=$(echo "$PACKAGES" | jq -c '. + ["fixture-generator"]')
@@ -60,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         # Parse JSON array containing names of all changed light client packages,
-        # e.g. ['aptos', 'ethereum', 'kadena'] if `aptos`, `ethereum` and 'kadena' contain changes.
+        # e.g. ['aptos', 'ethereum', 'kadena'] if `aptos`, `ethereum` and `kadena` contain changes.
         package: ${{ fromJSON(needs.changes.outputs.lc-packages) }}
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         # Parse JSON array containing names of all changed packages,
-        # e.g. ['aptos', 'ethereum', 'kadena'] if `aptos`, `ethereum` and 'kadena' contain changes.
+        # e.g. ['aptos', 'ethereum', 'kadena', 'fixture-generator'] if `aptos`, `ethereum` and `kadena` contain changes.
         # We always run 'fixture-generator' clippy tests if it or any light client was changed.
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
     steps:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,19 +1,17 @@
+# Workflow to create a new tag release when a release branch is merged
 name: Tag release
 
 on:
   pull_request:
     types: [ closed ]
     branches:
-      - dev
       - release/*
 
 jobs:
-  # Creates a new tag if a release branch is merged
   tag-bump:
     if: |
       github.event.pull_request.merged == true &&
-      ((startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.base.ref == 'dev') ||
-      (startsWith(github.event.pull_request.head.ref, 'hotfix/') && startsWith(github.event.pull_request.base.ref, 'release/')))
+      ((github.event.pull_request.head.ref == 'version-bump') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     runs-on: ubuntu-latest
     steps:
       - name: Git config
@@ -29,45 +27,39 @@ jobs:
       - name: Get version
         id: get-version
         run: |
-          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2)
-          RELEASE_BRANCH="${{ startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.head.ref || github.event.pull_request.base.ref }}"
-          PATH=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2 | cut -d'.' -f 1)
+          RELEASE_BRANCH=${{ github.event.pull_request.base.ref }}
+          TAG_VERSION=$(echo "$RELEASE_BRANCH" | cut -d'/' -f 2)
+          LC_PATH=$(echo "$RELEASE_BRANCH" | awk -F'/' '{split($2, arr, "-"); print arr[1]}')
 
-          if [[ "${{ startsWith(github.event.pull_request.head.ref, 'release/') }}" == "true" ]]; then
-            VERSION="${VERSION}.0"
-          fi
+          if [[ "${{ github.event.pull_request.head.ref }}" == "version-bump" ]]; then
+            TAG_VERSION=$(echo "$RELEASE_BRANCH" | cut -d'/' -f 2)
+            TAG_VERSION="${TAG_VERSION}.0"
+          else
+            TAG_VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2)
+           fi
 
-          git tag -a $VERSION -m "$VERSION" origin/$RELEASE_BRANCH
-          git push origin $VERSION --follow-tags          
-          echo "path=$PATH" | tee -a "$GITHUB_OUTPUT"
-          echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+          git tag -a $TAG_VERSION -m "$TAG_VERSION" origin/$RELEASE_BRANCH
+          git push origin $TAG_VERSION --follow-tags
+          echo "path=$LC_PATH" | tee -a "$GITHUB_OUTPUT"
+          echo "tag-version=$TAG_VERSION" | tee -a "$GITHUB_OUTPUT"
           echo "RELEASE_BRANCH=$RELEASE_BRANCH" | tee -a "$GITHUB_ENV"
 
 
       - name: Get latest release reference
         id: get-latest-release
         run: |
-          if [[ "${{ startsWith(github.event.pull_request.head.ref, 'release/') }}" == "true" ]]; then
-            REGEX=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f 2 | cut -d'.' -f 1)
-            LATEST_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 100 | grep -Ei "$REGEX" | head -n 1)
+          LATEST_RELEASE=$(gh release list --repo ${{ github.repository }} --limit 100 | grep -Ei "${{ steps.get-version.outputs.path }}" | head -n 1 | awk '{ print $1 }')
 
-            if [ -z "$LATEST_RELEASE" ]; then
-              FIRST_COMMIT=$(git rev-list --max-parents=0 dev#refs/heads/)
-
-              echo "The first commit on branch dev is $FIRST_COMMIT"
-              echo "latest_release=$FIRST_COMMIT" | tee -a "$GITHUB_OUTPUT"      
-            else
-              echo "Found release: $LATEST_RELEASE"
-              echo "latest_release=$LATEST_RELEASE" | tee -a "$GITHUB_OUTPUT"      
-            fi
-
+          if [ -z "$LATEST_RELEASE" ]; then
+            LATEST_RELEASE=$(git rev-list --max-parents=0 HEAD)
+            echo "The first commit on branch ${{ env.RELEASE_BRANCH }} is $LATEST_RELEASE"
           else
-            REGEX=$(echo "${{ github.event.pull_request.base.ref }}" | cut -d'/' -f 2)
-            LATEST_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 100 | grep -Ei "$REGEX" | head -n 1)
-
             echo "Found release: $LATEST_RELEASE"
-            echo "latest_release=$LATEST_RELEASE" | tee -a "$GITHUB_OUTPUT"
           fi
+
+          echo "latest_release=$LATEST_RELEASE" | tee -a "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build Changelog
         id: github_release
@@ -75,7 +67,7 @@ jobs:
         with:
           path: "./${{ steps.get-version.outputs.path }}"
           fromTag: ${{ steps.get-latest-release.outputs.latest_release }}
-          toTag: ${{ steps.get-version.outputs.version }}
+          toTag: ${{ steps.get-version.outputs.tag-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -83,6 +75,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           body: ${{ steps.github_release.outputs.changelog }}
-          tag: ${{ steps.get-version.outputs.version }}
+          tag: ${{ steps.get-version.outputs.tag-version }}
           commit: ${{ env.RELEASE_BRANCH }}
           allowUpdates: true


### PR DESCRIPTION
## Overview
Refactors the release workflows to not merge new releases into `dev`, which was causing ZKLC `dev` to be pinned to upstream releases rather than `dev` on e.g. Sphinx. Instead, the release branches are now the base of the version bump PR.

## New release
- Pushes a new `release/<light-client>-v<version>` branch based on latest `dev`
- Creates a new branch from the release, then bumps the version with the `version` input
- Opens a PR from the `version-bump` branch to the release branch
- When merged, triggers a release from `tag-release.yml` check out a new `release/<light-client>-v<version>` branch

## Hotfix
- Creates a new branch `hotfix/<light-client>-v<version>` based on `release/<light-client>-v<version>`
- Bumps the patch version and opens a PR
- When merged, triggers the release process.

## Notes
- This approach has the benefit of allowing us to delete all head branches after merge, letting the base `release/` branches rely on solely branch protection rules to prevent deletion.
- Release PRs just bump the version numbers, and still require manually updating Sphinx dependency versions as needed (as noted in the PR description) before merge.
- The `tag-release.yml` workflow triggers on `pull_request`, so any changes to that file (such as this PR) must be pulled into existing `release/` branches in order for them to take effect. The `bump-version-PR.yml` file triggers on `workflow_dispatch`, so the code runs from `dev`. 

Partially addresses #166

Successful runs: 
New release: https://github.com/samuelburnham/zk-light-clients/pull/14, https://github.com/samuelburnham/zk-light-clients/releases/tag/aptos-v3.0.0
Hotfix: https://github.com/samuelburnham/zk-light-clients/pull/15, https://github.com/samuelburnham/zk-light-clients/releases/tag/aptos-v3.0.1