### PR TITLE
fix: Pass stdin as a ref

### DIFF
--- a/ethereum/light-client/benches/committee_change.rs
+++ b/ethereum/light-client/benches/committee_change.rs
@@ -92,7 +92,7 @@ fn main() {
     let start_proving = Instant::now();
     let proof = benchmark_assets
         .prover
-        .prove(inputs, mode)
+        .prove(&inputs, mode)
         .expect("Failed to prove committee change");
     let proving_time = start_proving.elapsed();
 

--- a/ethereum/light-client/benches/inclusion.rs
+++ b/ethereum/light-client/benches/inclusion.rs
@@ -103,7 +103,7 @@ fn main() {
     let start_proving = Instant::now();
     let proof = benchmark_assets
         .prover
-        .prove(inputs, mode)
+        .prove(&inputs, mode)
         .expect("Failed to prove storage inclusion");
     let proving_time = start_proving.elapsed();
 

--- a/ethereum/light-client/src/bin/server_primary.rs
+++ b/ethereum/light-client/src/bin/server_primary.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
                         info!("Start proving");
                         let proof_handle = spawn_blocking(move || {
                             let (proving_mode, inputs) = *boxed;
-                            committee_prover.prove(inputs, proving_mode)
+                            committee_prover.prove(&inputs, proving_mode)
                         });
                         let proof = proof_handle.await??;
                         info!("Proof generated. Serializing");

--- a/ethereum/light-client/src/bin/server_secondary.rs
+++ b/ethereum/light-client/src/bin/server_secondary.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
                         info!("Start proving");
                         let proof_handle = spawn_blocking(move || {
                             let (proving_mode, inputs) = *boxed;
-                            inclusion_prover.prove(inputs, proving_mode)
+                            inclusion_prover.prove(&inputs, proving_mode)
                         });
                         let proof = proof_handle.await??;
                         info!("Proof generated. Serializing");

--- a/ethereum/light-client/src/proofs/committee_change.rs
+++ b/ethereum/light-client/src/proofs/committee_change.rs
@@ -162,7 +162,7 @@ impl Prover for CommitteeChangeProver {
     type StdIn = CommitteeChangeIn;
     type StdOut = CommitteeChangeOut;
 
-    fn generate_sphinx_stdin(&self, inputs: Self::StdIn) -> Result<SphinxStdin, Self::Error> {
+    fn generate_sphinx_stdin(&self, inputs: &Self::StdIn) -> Result<SphinxStdin, Self::Error> {
         let mut stdin = SphinxStdin::new();
         stdin.write(
             &inputs
@@ -179,7 +179,7 @@ impl Prover for CommitteeChangeProver {
         Ok(stdin)
     }
 
-    fn execute(&self, inputs: Self::StdIn) -> Result<Self::StdOut, Self::Error> {
+    fn execute(&self, inputs: &Self::StdIn) -> Result<Self::StdOut, Self::Error> {
         sphinx_sdk::utils::setup_logger();
 
         let stdin = self.generate_sphinx_stdin(inputs)?;
@@ -193,7 +193,7 @@ impl Prover for CommitteeChangeProver {
         Ok(CommitteeChangeOut::from(&mut public_values))
     }
 
-    fn prove(&self, inputs: Self::StdIn, mode: ProvingMode) -> Result<ProofType, Self::Error> {
+    fn prove(&self, inputs: &Self::StdIn, mode: ProvingMode) -> Result<ProofType, Self::Error> {
         let stdin = self.generate_sphinx_stdin(inputs)?;
 
         match mode {
@@ -257,7 +257,7 @@ mod test {
             update: test_assets.update_new_period.clone(),
         };
 
-        let new_period_output = prover.execute(new_period_inputs).unwrap();
+        let new_period_output = prover.execute(&new_period_inputs).unwrap();
 
         assert_eq!(
             &new_period_output.finalized_block_height,
@@ -317,7 +317,9 @@ mod test {
         println!("Starting STARK proving for sync committee change...");
         let start = Instant::now();
 
-        let _ = prover.prove(new_period_inputs, ProvingMode::STARK).unwrap();
+        let _ = prover
+            .prove(&new_period_inputs, ProvingMode::STARK)
+            .unwrap();
         println!("Proving took {:?}", start.elapsed());
     }
 
@@ -343,7 +345,9 @@ mod test {
         println!("Starting SNARK proving for sync committee change...");
         let start = Instant::now();
 
-        let _ = prover.prove(new_period_inputs, ProvingMode::SNARK).unwrap();
+        let _ = prover
+            .prove(&new_period_inputs, ProvingMode::SNARK)
+            .unwrap();
         println!("Proving took {:?}", start.elapsed());
     }
 }

--- a/ethereum/light-client/src/proofs/mod.rs
+++ b/ethereum/light-client/src/proofs/mod.rs
@@ -208,7 +208,7 @@ pub trait Prover {
     /// # Returns
     ///
     /// The Sphinx stdin.
-    fn generate_sphinx_stdin(&self, inputs: Self::StdIn) -> Result<SphinxStdin, Self::Error>;
+    fn generate_sphinx_stdin(&self, inputs: &Self::StdIn) -> Result<SphinxStdin, Self::Error>;
 
     /// Execute the program, useful to get the cycles that the program will take.
     ///
@@ -219,7 +219,7 @@ pub trait Prover {
     /// # Returns
     ///
     /// The output of the prover.
-    fn execute(&self, inputs: Self::StdIn) -> Result<Self::StdOut, Self::Error>;
+    fn execute(&self, inputs: &Self::StdIn) -> Result<Self::StdOut, Self::Error>;
 
     /// Generate a proof for the program. The proof can either be a STARK or a SNARK proof.
     ///
@@ -231,7 +231,7 @@ pub trait Prover {
     /// # Returns
     ///
     /// The proof.
-    fn prove(&self, inputs: Self::StdIn, mode: ProvingMode) -> Result<ProofType, Self::Error>;
+    fn prove(&self, inputs: &Self::StdIn, mode: ProvingMode) -> Result<ProofType, Self::Error>;
 
     /// Verify a proof for the program.
     ///

--- a/fixture-generator/src/bin/main.rs
+++ b/fixture-generator/src/bin/main.rs
@@ -133,7 +133,7 @@ fn generate_fixture_inclusion_ethereum_lc() {
         test_assets.finality_update().clone().into(),
         test_assets.eip1186_proof().clone(),
     );
-    let proof = match prover.prove(input, ProvingMode::SNARK).unwrap() {
+    let proof = match prover.prove(&input, ProvingMode::SNARK).unwrap() {
         ProofType::SNARK(inner_proof) => inner_proof,
         _ => {
             panic!("Unexpected proof")
@@ -225,7 +225,10 @@ fn generate_fixture_epoch_change_ethereum_lc() {
     let new_period_inputs =
         CommitteeChangeIn::new(test_assets.store, test_assets.update_new_period);
     let prover = CommitteeChangeProver::new();
-    let proof = match prover.prove(new_period_inputs, ProvingMode::SNARK).unwrap() {
+    let proof = match prover
+        .prove(&new_period_inputs, ProvingMode::SNARK)
+        .unwrap()
+    {
         ProofType::SNARK(inner_proof) => inner_proof,
         _ => {
             panic!("Unexpected proof")


### PR DESCRIPTION
Fixes #181

`CommitteeChangeIn` is a large struct (250KB) and passing it by value is enough to cause a stack overflow since initializing the sphinx prover requires a lot of recursive calls while building the recursive verifier programs. Passing it as a reference to `prove` changes the layout somehow, enough for the stack overflow issue to disappear.

As a rule of thumb, large structs like that shouldn't be passed around by value and it's better to pass by reference to prevent unnecessary implicit copying, but we don't currently have a great way of checking which structs are too large. Besides, this case was only an issue due to the heavy stack usage when initializing the sphinx prover, otherwise 250KB is not that much. To put in perspective, the default stack size is 8MiB, so the struct uses about 3% of the available stack space. I don't know what kind of codegen is leading to the stack overflow happening.

EDIT: Actually, the default stack size [seems to be 2MiB](https://doc.rust-lang.org/std/thread/#stack-size) for newly spawned threads (and `cargo test` spawns a new thread I believe?), 8MiB is the default for the main thread only I think, which would explain why the 250KB struct is enough to hit the stack limit when passed by value, if this is happening in a new thread. I didn't try changing `RUST_MIN_STACK` but that would confirm the issue.