### PR TITLE
chore: Remove superfluous nightly versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,9 +12,15 @@ runs:
       with:
         go-version: '1.22'
         cache-dependency-path: "**/go.sum"
-    - uses: dtolnay/rust-toolchain@master
+    # Assumes the `fixture-generator` Rust version is reasonably up to date with all of the light clients
+    - name: Get Rust toolchain version
+      shell: bash
+      run: |
+        echo "TOOLCHAIN_VERSION=$(grep -E '^channel\s*=' ./fixture-generator/rust-toolchain.toml | awk -F'"' '{ print $2 }')" | tee -a $GITHUB_ENV
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-05-31
+        toolchain: ${{ env.TOOLCHAIN_VERSION }}
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -59,9 +59,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup CI
         uses: ./.github/actions/setup
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-05-31
       - name: Install extra deps
         run: |
           sudo apt-get update && sudo apt-get install -y python3-pip

--- a/.github/workflows/bump-version-PR.yml
+++ b/.github/workflows/bump-version-PR.yml
@@ -48,9 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-05-31
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install `tq-rs`
         run: cargo install tq-rs

--- a/aptos/core/README.md
+++ b/aptos/core/README.md
@@ -22,7 +22,7 @@ chain. The code for this is located in the `aptos_test_utils` module.
 To run tests, we recommend the following command:
 
 ```shell
-SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 nextest run --verbose --release --profile ci --features aptos --package aptos-lc --no-capture
+SHARD_BATCH_SIZE=0 cargo nextest run --verbose --release --profile ci --features aptos --package aptos-lc --no-capture
 ```
 
 This command should be run with the following environment variable:

--- a/aptos/docs/src/benchmark/configuration.md
+++ b/aptos/docs/src/benchmark/configuration.md
@@ -30,13 +30,6 @@ Here are the standard config variables that are worth setting for any benchmark:
 
   This disables checkpointing making proving faster at the expense of higher memory usage
 
-- `cargo +nightly-2024-05-31`
-
-  This ensures you are on a nightly toolchain. Nightly allows usage of AVX512 instructions which is crucial for
-  performance. This is the same version set on `rust-toolchain.toml`. It's pinned
-  to a specific release (`v1.80.0-nightly`) to prevent unexpected issues caused
-  by newer Rust versions.
-
 - `cargo bench --release <...>`
 
   Make sure to always run in release mode with `--release`. Alternatively, specify the proper compiler options via

--- a/aptos/docs/src/benchmark/e2e.md
+++ b/aptos/docs/src/benchmark/e2e.md
@@ -10,7 +10,7 @@ the [`proof-server`](https://github.com/argumentcomputer/zk-light-clients/blob/d
 crate. It can be run with the following command:
 
 ```bash
-SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" PRIMARY_ADDR="127.0.0.1:8080" SECONDARY_ADDR="127.0.0.1:8081" cargo +nightly-2024-05-31 bench --bench proof_server
+SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" PRIMARY_ADDR="127.0.0.1:8080" SECONDARY_ADDR="127.0.0.1:8081" cargo bench --bench proof_server
 ```
 
 This benchmark will spawn the two servers locally and make two requests in sequence to them. This generates both proofs
@@ -54,7 +54,7 @@ For our [production configuration](../run/overview.md), we currently get the fol
 To enable SNARK proving, just pass the environment variable `SNARK=1` when running:
 
 ```bash
-SNARK=1 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" PRIMARY_ADDR="127.0.0.1:8080" SECONDARY_ADDR="127.0.0.1:8081" cargo +nightly-2024-05-31 bench --bench proof_server
+SNARK=1 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" PRIMARY_ADDR="127.0.0.1:8080" SECONDARY_ADDR="127.0.0.1:8081" cargo bench --bench proof_server
 ```
 
 For our [production configuration](../run/overview.md), we currently get the following results:

--- a/aptos/docs/src/benchmark/on_chain.md
+++ b/aptos/docs/src/benchmark/on_chain.md
@@ -69,7 +69,7 @@ export the fixture file to the relevant place (`solidity/contracts/src/plonk_fix
 To run the `fixture-generator` for the inclusion program, execute the following command:
 
 ```bash
-RUST_LOG=info RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 run --release --bin generate-fixture -- --program inclusion --language solidity
+RUST_LOG=info RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 cargo run --release --bin generate-fixture -- --program inclusion --language solidity
 ```
 
 > **Tips**

--- a/aptos/docs/src/benchmark/proof.md
+++ b/aptos/docs/src/benchmark/proof.md
@@ -71,7 +71,7 @@ Enter benchmark name: e2e
 Run the following command:
 
 ```shell
-SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 bench --features aptos --bench execute -- <benchmark_name>
+SHARD_BATCH_SIZE=0 cargo bench --features aptos --bench execute -- <benchmark_name>
 ```
 
 ## Interpreting the results
@@ -137,7 +137,7 @@ To run the test efficiently, first install `nextest` following [its documentatio
 Ensure that you also have the previously described environment variables set, then run the following command:
 
 ```shell
-SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 nextest run --verbose --release --profile ci --features aptos --package aptos-lc --no-capture
+SHARD_BATCH_SIZE=0 cargo nextest run --verbose --release --profile ci --features aptos --package aptos-lc --no-capture
 ```
 
 > **Note**

--- a/aptos/docs/src/run/configuration.md
+++ b/aptos/docs/src/run/configuration.md
@@ -8,10 +8,10 @@ Rust [here](https://www.rust-lang.org/tools/install) and for Golang [here](https
 Make sure to install **nightly** Rust, which is necessary for AVX-512 acceleration:
 
 ```bash
-rustup default nightly-2024-05-31
+rustup default nightly
 ```
 
-We pin the nightly Rust version to version `1.80.0-nightly (431db31d0 2024-05-28)` to prevent unknown future changes
+We pin the nightly Rust version in `rust-toolchain.toml` to prevent unknown future changes
 to nightly from interfering with the build process. In principle however, any recent nightly release of Rust should
 work.
 

--- a/aptos/docs/src/run/setup_client.md
+++ b/aptos/docs/src/run/setup_client.md
@@ -14,7 +14,7 @@ With our deployment machine properly configured, we can run the client.
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/aptos/proof-server && \
-  RUST_LOG="debug" cargo +nightly-2024-05-31 run -p proof-server --release --bin client -- --proof-server-address <PRIMARY_SERVER_ADDRESS> --aptos-node-url <APTOS_NODE_URL>
+  RUST_LOG="debug" cargo run -p proof-server --release --bin client -- --proof-server-address <PRIMARY_SERVER_ADDRESS> --aptos-node-url <APTOS_NODE_URL>
 ```
 
 The client only needs to communicate with the primary proof server, since requests to the secondary server are automatically forwarded.

--- a/aptos/docs/src/run/setup_proof_server.md
+++ b/aptos/docs/src/run/setup_proof_server.md
@@ -26,8 +26,6 @@ Make sure to finish the [initial configuration](./configuration.md) first.
         rustflags = ["--cfg", "tokio_unstable", "-C", "target-cpu=native", "-C", "opt-level=3"]
         ```
         
-Make sure to launch the proof servers with `cargo +nightly-2024-05-31`.
-
 > **Note**
 >
 > One can also set the `RUST_LOG` environment variable to `debug` to get more information
@@ -40,7 +38,7 @@ Now that our deployment machine is properly configured, we can run the secondary
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/aptos/proof-server && \
-  SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" cargo +nightly-2024-05-31 run --release --bin server_secondary -- -a <NETWORK_ADDRESS>
+  SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" cargo run --release --bin server_secondary -- -a <NETWORK_ADDRESS>
 ```
 
 ## Deploy the primary server
@@ -50,5 +48,5 @@ Finally, once the primary server is configured in the same fashion, run it:
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/aptos/proof-server && \
-  SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" cargo +nightly-2024-05-31 run --release --bin server_primary -- -a <NETWORK_ADDESS> --snd-addr <SECONDARY_SERVER_ADDRESS>
+  SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" cargo run --release --bin server_primary -- -a <NETWORK_ADDESS> --snd-addr <SECONDARY_SERVER_ADDRESS>
 ```

--- a/aptos/light-client/Makefile
+++ b/aptos/light-client/Makefile
@@ -5,7 +5,7 @@ benchmark:
 	RUST_LOG="debug" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_BATCH_SIZE=0 \
-	cargo +nightly-2024-05-31 bench --features aptos --bench $$bench
+	cargo bench --features aptos --bench $$bench
 
 BENCH ?= e2e
 
@@ -13,4 +13,4 @@ bench-ci:
 	RUST_LOG="info" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_BATCH_SIZE=0 \
-	cargo +nightly-2024-05-31 bench --features aptos --bench $(BENCH)
+	cargo bench --features aptos --bench $(BENCH)

--- a/aptos/proof-server/benches/proof_server.rs
+++ b/aptos/proof-server/benches/proof_server.rs
@@ -113,7 +113,6 @@ async fn start_primary_server(final_snark: bool) -> Result<Child, anyhow::Error>
 
     let process = Command::new("cargo")
         .args([
-            "+nightly-2024-05-31",
             "run",
             "--release",
             "--bin",
@@ -163,7 +162,6 @@ async fn start_secondary_server(final_snark: bool) -> Result<Child, anyhow::Erro
 
     let process = Command::new("cargo")
         .args([
-            "+nightly-2024-05-31",
             "run",
             "--release",
             "--bin",

--- a/ethereum/docs/src/benchmark/configuration.md
+++ b/ethereum/docs/src/benchmark/configuration.md
@@ -30,14 +30,6 @@ Here are the standard config variables that are worth setting for any benchmark:
 
   This disables checkpointing making proving faster at the expense of higher memory usage
 
-- `cargo +nightly-2024-05-31`
-
-  This ensures you are on a nightly toolchain. Nightly allows usage of AVX512 instructions which is crucial for
-  performance.
-  This is the same version set on `rust-toolchain.toml`. It's pinned to a specific release (`v1.80.0-nightly`) to
-  prevent
-  unexpected issues caused by newer Rust versions.
-
 - `cargo bench --release <...>`
 
   Make sure to always run in release mode with `--release`. Alternatively, specify the proper compiler options via

--- a/ethereum/docs/src/benchmark/on_chain.md
+++ b/ethereum/docs/src/benchmark/on_chain.md
@@ -96,5 +96,5 @@ To run the `fixture-generator` for the inclusion program, execute the following 
 
 ```bash
 cd fixture-generator
-RUST_LOG=info RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 run --release --bin generate-fixture -- --program inclusion --language move
+RUST_LOG=info RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3" SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 cargo run --release --bin generate-fixture -- --program inclusion --language move
 ```

--- a/ethereum/docs/src/benchmark/proof.md
+++ b/ethereum/docs/src/benchmark/proof.md
@@ -88,7 +88,7 @@ Enter benchmark name: committee_change
 Run the following command:
 
 ```shell
-SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 bench --bench execute -- <benchmark_name>
+SHARD_BATCH_SIZE=0 cargo bench --bench execute -- <benchmark_name>
 ```
 
 ## Interpreting the results
@@ -148,7 +148,7 @@ To run the test efficiently, first install
 `nextest` following [its documentation](https://nexte.st/book/installation). Ensure that you also have the previously described environment variables set, then run the following command:
 
 ```shell
-SHARD_BATCH_SIZE=0 cargo +nightly-2024-05-31 nextest run --verbose --release --profile ci --package ethereum-lc --no-capture --all-features
+SHARD_BATCH_SIZE=0 cargo nextest run --verbose --release --profile ci --package ethereum-lc --no-capture --all-features
 ```
 
 > **Note**

--- a/ethereum/docs/src/run/configuration.md
+++ b/ethereum/docs/src/run/configuration.md
@@ -8,10 +8,10 @@ Rust [here](https://www.rust-lang.org/tools/install) and for Golang [here](https
 Make sure to install **nightly** Rust, which is necessary for AVX-512 acceleration:
 
 ```bash
-rustup default nightly-2024-05-31
+rustup default nightly
 ```
 
-We pin the nightly Rust version to version `1.80.0-nightly (431db31d0 2024-05-28)` to prevent unknown future changes
+We pin the nightly Rust version in `rust-toolchain.toml` to prevent unknown future changes
 to nightly from interfering with the build process. In principle however, any recent nightly release of Rust should
 work.
 

--- a/ethereum/docs/src/run/setup_client.md
+++ b/ethereum/docs/src/run/setup_client.md
@@ -17,7 +17,7 @@ environment variable `MODE` can be set to either `STARK` or `SNARK`. The default
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/ethereum && \
-  MODE=SNARK RUST_LOG="debug" cargo +nightly-2024-05-31 run -p light-client --release --bin client -- -c <CHECKPOINT_PROVIDER_ADDRESS> -b <BEACON_NODE_ADDRESS> -p <PROOF_SERVER_ADDRESS> -r <RPC_PROVIDER_ADDRESS>
+  MODE=SNARK RUST_LOG="debug" cargo run -p light-client --release --bin client -- -c <CHECKPOINT_PROVIDER_ADDRESS> -b <BEACON_NODE_ADDRESS> -p <PROOF_SERVER_ADDRESS> -r <RPC_PROVIDER_ADDRESS>
 ```
 
 The client only needs to communicate with the primary proof server, since requests to the secondary server are automatically forwarded.

--- a/ethereum/docs/src/run/setup_proof_server.md
+++ b/ethereum/docs/src/run/setup_proof_server.md
@@ -24,8 +24,6 @@ Make sure to finish the [initial configuration](./configuration.md) first.
         rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
         ```
 
-Make sure to launch the proof servers with `cargo +nightly-2024-05-31`.
-
 > **Note**
 >
 > One can also set the `RUST_LOG` environment variable to `debug` to get more information
@@ -38,7 +36,7 @@ Now that our deployment machine is properly configured, we can run the secondary
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/aptos/proof-server && \
-  SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native -C opt-level=3" cargo +nightly-2024-05-31 run --release --bin server_secondary -- -a <NETWORK_ADDRESS>
+  SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native -C opt-level=3" cargo run --release --bin server_secondary -- -a <NETWORK_ADDRESS>
 ```
 
 ## Deploy the primary server
@@ -48,5 +46,5 @@ Finally, once the primary server is configured in the same fashion, run it:
 ```bash
 git clone git@github.com:argumentcomputer/zk-light-clients.git && \
   cd zk-light-clients/ethereum/light-client && \
-  SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native -C opt-level=3" cargo +nightly-2024-05-31 run --release --bin server_primary -- -a <NETWORK_ADDESS> --snd-addr <SECONDARY_SERVER_ADDRESS>
+  SHARD_SIZE=4194304 SHARD_BATCH_SIZE=0 RUSTFLAGS="-C target-cpu=native -C opt-level=3" cargo run --release --bin server_primary -- -a <NETWORK_ADDESS> --snd-addr <SECONDARY_SERVER_ADDRESS>
 ```

--- a/ethereum/light-client/Makefile
+++ b/ethereum/light-client/Makefile
@@ -5,7 +5,7 @@ benchmark:
 	RUST_LOG="debug" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_BATCH_SIZE=0 \
-	cargo +nightly-2024-05-31 bench --bench $$bench
+	cargo bench --bench $$bench
 
 BENCH ?= e2e
 
@@ -13,4 +13,4 @@ bench-ci:
 	RUST_LOG="info" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_BATCH_SIZE=0 \
-	cargo +nightly-2024-05-31 bench --bench $(BENCH)
+	cargo bench --bench $(BENCH)

--- a/kadena/docs/src/benchmark/configuration.md
+++ b/kadena/docs/src/benchmark/configuration.md
@@ -30,14 +30,6 @@ Here are the standard config variables that are worth setting for any benchmark:
 
   This disables checkpointing making proving faster at the expense of higher memory usage
 
-- `cargo +nightly-2024-05-31`
-
-  This ensures you are on a nightly toolchain. Nightly allows usage of AVX512 instructions which is crucial for
-  performance.
-  This is the same version set on `rust-toolchain.toml`. It's pinned to a specific release (`v1.80.0-nightly`) to
-  prevent
-  unexpected issues caused by newer Rust versions.
-
 - `cargo bench --release <...>`
 
   Make sure to always run in release mode with `--release`. Alternatively, specify the proper compiler options via

--- a/kadena/docs/src/run/configuration.md
+++ b/kadena/docs/src/run/configuration.md
@@ -8,10 +8,10 @@ Rust [here](https://www.rust-lang.org/tools/install) and for Golang [here](https
 Make sure to install **nightly** Rust, which is necessary for AVX-512 acceleration:
 
 ```bash
-rustup default nightly-2024-05-31
+rustup default nightly
 ```
 
-We pin the nightly Rust version to version `1.80.0-nightly (431db31d0 2024-05-28)` to prevent unknown future changes
+We pin the nightly Rust version in `rust-toolchain.toml` to prevent unknown future changes
 to nightly from interfering with the build process. In principle however, any recent nightly release of Rust should
 work.
 


### PR DESCRIPTION
Fixes #162 by relying on the nightly version pinned in `rust-toolchain.toml` as the sole source of truth. It's a bug if anything runs with a different Rust version by default.

I left the nightly docs in each LC's `docs/src/run/configuration.md` for an explanation of this behavior.