### PR TITLE
ci: Use custom runner for `bench.yml`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -77,11 +77,9 @@ jobs:
           pip3 install jtbl
       - name: Set env
         run: |
-          # Default benchmark settings optimized for Aptos, can be overwritten with `env` input
-          echo "RUST_LOG=debug" | tee -a $GITHUB_ENV
+          # Default benchmark settings optimized for light clients, can be overwritten with `env` input
           echo "RUSTFLAGS='-C target-cpu=native --cfg tokio_unstable -C opt-level=3'" | tee -a $GITHUB_ENV
           echo "SHARD_SIZE=4194304" | tee -a $GITHUB_ENV
-          echo "SHARD_BATCH_SIZE=0" | tee -a $GITHUB_ENV
           echo "SHARD_CHUNKING_MULTIPLIER=256" | tee -a $GITHUB_ENV
           echo "SNARK=1" | tee -a $GITHUB_ENV
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,42 +1,54 @@
 # Runs benchmarks on self-hosted infra via `workflow_dispatch`
-# This trigger can be found at https://github.com/wormhole-foundation/example-zk-light-clients-internal/actions/workflows/bench.yml
+# This trigger can be found at https://github.com/argumentcomputer/zk-light-clients/actions/workflows/bench.yml
 #
-# The output can be found in the logs or in a comment on the latest commit. This can be viewed on GitHub at the bottom of the commit page.
-# See https://github.com/wormhole-foundation/example-zk-light-clients-internal/commit/3d06c3585e94fe027bf7dacf865106c259994c85#comments
-name: Manual benchmark
+# The benchmark report can be found in the logs and as a comment on the latest commit on `dev`.
+# The report can also be sent as a Zulip message to https://zulip.argument.xyz
+name: Light client benchmark
 on:
   workflow_dispatch:
     inputs:
       # Which light client to bench, e.g. `aptos`, `ethereum` or `kadena`
-      package:
+      light-client:
+        description: 'Name of the light client to benchmark'
         type: string
         required: true
-      # Name of the `light-client` benchmark to run
+      # Name of the `light-client` benchmark to run, e.g. `inclusion`
+      # Runs in the `light-client` directory, so it cannot benchmark `proof_server` or `programs`
       bench-name:
+        description: 'Name of the benchmark to run'
         type: string
         required: true
+      # List of comma-separated env vars, e.g. `RUST_LOG=debug,SNARK=1`
+      # `RUSTFLAGS="-C target-cpu=native --cfg tokio_unstable -C opt-level=3"` is set by default
+      env:
+        description: 'List of comma-separated environment variables'
+        type: string
+        required: false
       # Optionally send a message to the below Zulip streams
       # Defaults to false
       zulip:
+        description: 'Send the report to Zulip'
         type: boolean
         required: false
       # User(s) to whom to send a private DM (optional)
       # Comma-separated list of user ID integers, e.g. `11,12` (IDs can be found in user profiles)
       # If not specified, sends to a stream/topic pair instead
       private:
-        description: 'DM given user ID(s)'
+        description: 'Send DM to given user ID(s)'
         type: string
         required: false
       # Zulip stream in which to send the message (optional)
       # Ignored if `private` input is specified
       # Defaults to `light_client` stream
-      stream:
+      channel:
+        description: 'Send message to channel (default is `light-client`). Ignored if `private`'
         type: string
         required: false
       # Zulip topic in which to send the message (optional)
       # Ignored if `private` input is specified
       # Defaults to `chat`
       topic:
+        description: 'Send message to topic (default is `chat`). Ignored if `private`'
         type: string
         required: false
   schedule:
@@ -49,8 +61,8 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Manual benchmark
-    runs-on: [ self-hosted, bench, avx512 ]
+    name: Light client benchmark
+    runs-on: warp-custom-r7iz-metal-16xl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,7 +75,23 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y python3-pip
           pip3 install jtbl
-      - name: Parse inputs
+      - name: Set env
+        run: |
+          # Default benchmark settings optimized for Aptos, can be overwritten with `env` input
+          echo "RUST_LOG=debug" | tee -a $GITHUB_ENV
+          echo "RUSTFLAGS='-C target-cpu=native --cfg tokio_unstable -C opt-level=3'" | tee -a $GITHUB_ENV
+          echo "SHARD_SIZE=4194304" | tee -a $GITHUB_ENV
+          echo "SHARD_BATCH_SIZE=0" | tee -a $GITHUB_ENV
+          echo "SHARD_CHUNKING_MULTIPLIER=256" | tee -a $GITHUB_ENV
+          echo "SNARK=1" | tee -a $GITHUB_ENV
+
+          IFS=',' read -ra ENV_VARS <<< "${{ inputs.env }}"
+          for VAR in "${ENV_VARS[@]}"; do
+            VAR_NAME="${VAR%%=*}"
+            VAR_VALUE="${VAR#*=}"
+            echo "${VAR_NAME}=${VAR_VALUE}" | tee -a $GITHUB_ENV
+          done
+      - name: Parse Zulip inputs
         run: |
           if [[ "${{ inputs.zulip }}" == "true" ]]; then
             if [[ ! -z "${{ inputs.private }}" ]]; then
@@ -92,8 +120,8 @@ jobs:
         run: |
           make bench-ci BENCH=${{ inputs.bench-name }} 2>&1 | tee out.txt
 
-          grep 'cycles=' out.txt >> cycles.txt
-          grep 'proving_time' out.txt >> timings.txt
+          grep 'cycles=' out.txt > cycles.txt
+          grep 'proving_time' out.txt > timings.txt
 
           while IFS=$'\t' read -r f1 f2
           do

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -80,6 +80,8 @@ jobs:
           # Default benchmark settings optimized for light clients, can be overwritten with `env` input
           echo "RUSTFLAGS='-C target-cpu=native --cfg tokio_unstable -C opt-level=3'" | tee -a $GITHUB_ENV
           echo "SHARD_SIZE=4194304" | tee -a $GITHUB_ENV
+          echo "SHARD_BATCH_SIZE=0" | tee -a $GITHUB_ENV
+          echo "RECONSTRUCT_COMMITMENTS=false" | tee -a $GITHUB_ENV
           echo "SHARD_CHUNKING_MULTIPLIER=256" | tee -a $GITHUB_ENV
           echo "SNARK=1" | tee -a $GITHUB_ENV
 

--- a/aptos/docs/src/benchmark/configuration.md
+++ b/aptos/docs/src/benchmark/configuration.md
@@ -37,7 +37,7 @@ Here are the standard config variables that are worth setting for any benchmark:
 
 - `RUST_LOG=debug` _(optional)_
 
-  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc.
+  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc. NOTE: This may cause a significant performance degradation, and is only recommended for collecting metrics other than wall clock time.
 
 ## SNARK proofs
 

--- a/aptos/light-client/Makefile
+++ b/aptos/light-client/Makefile
@@ -10,7 +10,4 @@ benchmark:
 BENCH ?= e2e
 
 bench-ci:
-	RUST_LOG="info" \
-	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
-	SHARD_BATCH_SIZE=0 \
 	cargo bench --features aptos --bench $(BENCH)

--- a/aptos/light-client/Makefile
+++ b/aptos/light-client/Makefile
@@ -4,7 +4,9 @@ benchmark:
 	@read -p "Enter benchmark name: " bench; \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_SIZE=4194304 \
+	SHARD_BATCH_SIZE=0 \
 	SHARD_CHUNKING_MULTIPLIER=256 \
+	RECONSTRUCT_COMMITMENTS=false \
 	cargo bench --features aptos --bench $$bench
 
 BENCH ?= e2e

--- a/aptos/light-client/Makefile
+++ b/aptos/light-client/Makefile
@@ -2,9 +2,9 @@
 
 benchmark:
 	@read -p "Enter benchmark name: " bench; \
-	RUST_LOG="debug" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
-	SHARD_BATCH_SIZE=0 \
+	SHARD_SIZE=4194304 \
+	SHARD_CHUNKING_MULTIPLIER=256 \
 	cargo bench --features aptos --bench $$bench
 
 BENCH ?= e2e

--- a/ethereum/core/Cargo.toml
+++ b/ethereum/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 edition = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-homepage = "https://github.com/wormhole-foundation/example-zk-light-clients"
+homepage = "https://github.com/argumentcomputer/zk-light-clients"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/ethereum/docs/src/benchmark/configuration.md
+++ b/ethereum/docs/src/benchmark/configuration.md
@@ -37,7 +37,7 @@ Here are the standard config variables that are worth setting for any benchmark:
 
 - `RUST_LOG=debug` _(optional)_
 
-  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc.
+  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc. NOTE: This may cause a significant performance degradation, and is only recommended for collecting metrics other than wall clock time.
 
 ## SNARK proofs
 

--- a/ethereum/light-client/Makefile
+++ b/ethereum/light-client/Makefile
@@ -5,12 +5,9 @@ benchmark:
 	RUST_LOG="debug" \
 	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
 	SHARD_BATCH_SIZE=0 \
-	cargo bench --bench $$bench
+	cargo bench --features ethereum --bench $$bench
 
 BENCH ?= e2e
 
 bench-ci:
-	RUST_LOG="info" \
-	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
-	SHARD_BATCH_SIZE=0 \
-	cargo bench --bench $(BENCH)
+	cargo bench --features ethereum --bench $(BENCH)

--- a/ethereum/light-client/Makefile
+++ b/ethereum/light-client/Makefile
@@ -2,12 +2,12 @@
 
 benchmark:
 	@read -p "Enter benchmark name: " bench; \
-	RUST_LOG="debug" \
-	RUSTFLAGS="--cfg tokio_unstable -C target-cpu=native -C opt-level=3" \
-	SHARD_BATCH_SIZE=0 \
+	RUSTFLAGS="-C target-cpu=native -C opt-level=3" \
+	SHARD_SIZE=4194304 \
+	SHARD_CHUNKING_MULTIPLIER=256 \
 	cargo bench --features ethereum --bench $$bench
 
-BENCH ?= e2e
+BENCH ?= committee_change
 
 bench-ci:
 	cargo bench --features ethereum --bench $(BENCH)

--- a/ethereum/light-client/Makefile
+++ b/ethereum/light-client/Makefile
@@ -4,7 +4,9 @@ benchmark:
 	@read -p "Enter benchmark name: " bench; \
 	RUSTFLAGS="-C target-cpu=native -C opt-level=3" \
 	SHARD_SIZE=4194304 \
+	SHARD_BATCH_SIZE=0 \
 	SHARD_CHUNKING_MULTIPLIER=256 \
+	RECONSTRUCT_COMMITMENTS=false \
 	cargo bench --features ethereum --bench $$bench
 
 BENCH ?= committee_change

--- a/kadena/docs/src/benchmark/configuration.md
+++ b/kadena/docs/src/benchmark/configuration.md
@@ -37,7 +37,7 @@ Here are the standard config variables that are worth setting for any benchmark:
 
 - `RUST_LOG=debug` _(optional)_
 
-  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc.
+  This prints out useful Sphinx metrics, such as cycle counts, iteration speed, proof size, etc. NOTE: This may cause a significant performance degradation, and is only recommended for collecting metrics other than wall clock time.
 
 ## SNARK proofs
 


### PR DESCRIPTION
- Switches from a self-hosted benchmark runner to a [Warpbuild custom runner](https://www.warpbuild.com/blog/launch-byoc), which handles spinning up and down the AWS instance, containerizing, and autoscaling the self-hosted runners.
- Adds default env vars for benchmarking and user input to customize

Successful run: https://github.com/argumentcomputer/ci-lab/actions/runs/10528494329

Requires further testing after merge