### PR TITLE
chore: use let-else more effectively

### DIFF
--- a/aptos/proof-server/src/bin/proof_server.rs
+++ b/aptos/proof-server/src/bin/proof_server.rs
@@ -145,7 +145,11 @@ async fn inclusion_proof(
 
     let request = res.unwrap();
 
-    let res = if let Request::ProveInclusion(boxed) = request {
+    let Request::ProveInclusion(boxed) = request else {
+        error!("Invalid request type");
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let res = {
         info!("Start proving");
 
         let (proof_type, inclusion_data) = boxed.as_ref();
@@ -184,9 +188,6 @@ async fn inclusion_proof(
             error!("Failed to serialize epoch change proof: {err}");
             StatusCode::INTERNAL_SERVER_ERROR
         })
-    } else {
-        error!("Invalid request type");
-        Err(StatusCode::BAD_REQUEST)
     }?;
 
     let response = Response::builder()
@@ -218,7 +219,11 @@ async fn inclusion_verify(
 
     let request = res.unwrap();
 
-    let res = if let Request::VerifyInclusion(proof) = request {
+    let Request::VerifyInclusion(proof) = request else {
+        error!("Invalid request type");
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let res = {
         info!("Start verifying inclusion proof");
 
         let is_valid = state
@@ -232,9 +237,6 @@ async fn inclusion_verify(
             error!("Failed to serialize inclusion verification result");
             StatusCode::INTERNAL_SERVER_ERROR
         })
-    } else {
-        error!("Invalid request type");
-        Err(StatusCode::BAD_REQUEST)
     }?;
 
     let response = Response::builder()
@@ -266,7 +268,11 @@ async fn epoch_proof(
 
     let request = res.unwrap();
 
-    let res = if let Request::ProveEpochChange(boxed) = request {
+    let Request::ProveEpochChange(boxed) = request else {
+        error!("Invalid request type");
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let res = {
         match state.mode {
             Mode::Single => {
                 let (proof_type, epoch_change_data) = boxed.as_ref();
@@ -309,9 +315,6 @@ async fn epoch_proof(
                 forward_request(bytes.to_vec(), &snd_addr).await
             }
         }
-    } else {
-        error!("Invalid request type");
-        Err(StatusCode::BAD_REQUEST)
     }?;
 
     let response = Response::builder()
@@ -345,7 +348,11 @@ async fn epoch_verify(
 
     let request = res.unwrap();
 
-    let res = if let Request::VerifyEpochChange(proof) = request {
+    let Request::VerifyEpochChange(proof) = request else {
+        error!("Invalid request type");
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let res = {
         let is_valid = state.prover_client.verify(&proof, &state.epoch_vk).is_ok();
 
         info!("Epoch change verification result: {}", is_valid);
@@ -354,9 +361,6 @@ async fn epoch_verify(
             error!("Failed to serialize epoch change verification result");
             StatusCode::INTERNAL_SERVER_ERROR
         })
-    } else {
-        error!("Invalid request type");
-        Err(StatusCode::BAD_REQUEST)
     }?;
 
     let response = Response::builder()

--- a/fixture-generator/Cargo.lock
+++ b/fixture-generator/Cargo.lock
@@ -2231,6 +2231,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.14",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,6 +3979,8 @@ name = "ethereum-lc"
 version = "1.0.1"
 dependencies = [
  "anyhow",
+ "axum 0.7.5",
+ "backoff",
  "clap 4.5.16",
  "env_logger",
  "ethereum-lc-core",


### PR DESCRIPTION
Essentially auto-generated with 

`rustby 'let :[nm] = if let :[pat] = :[var] { :[a] } else { :[pre] Err(:[b]) }?;' 'let :[pat] = :[var] else { :[pre] return Err(:[b]) }; let :[nm] = { :[a] }?;'`

Where
`rustby: aliased to comby -matcher .rs -extensions .rs -in-place -jobs 10 -exclude-dir "target,.github" -stats -timeout 15 $@`