### PR TITLE
fix: ethereum lc

### DIFF
--- a/ethereum/light-client/src/bin/proof_server.rs
+++ b/ethereum/light-client/src/bin/proof_server.rs
@@ -286,7 +286,7 @@ async fn forward_request(request_bytes: &[u8], snd_addr: &str) -> Result<Vec<u8>
     info!("Connecting to the secondary server");
     let client = reqwest::Client::new();
     let res = client
-        .post(format!("http://{}/proof", snd_addr))
+        .post(format!("http://{}/committee/proof", snd_addr))
         .body(request_bytes.to_vec())
         .header(CONTENT_TYPE, "application/octet-stream")
         .send()

--- a/ethereum/light-client/src/client/mod.rs
+++ b/ethereum/light-client/src/client/mod.rs
@@ -173,7 +173,7 @@ impl Client {
     pub async fn prove_committee_change(
         &self,
         proving_mode: ProvingMode,
-        store: LightClientStore,
+        store: Box<LightClientStore>,
         update: Update,
     ) -> Result<ProofType, ClientError> {
         Box::pin(
@@ -247,7 +247,7 @@ impl Client {
     pub async fn prove_storage_inclusion(
         &self,
         proving_mode: ProvingMode,
-        store: LightClientStore,
+        store: Box<LightClientStore>,
         update: Update,
         eip1186_proof: EIP1186Proof,
     ) -> Result<ProofType, ClientError> {

--- a/ethereum/light-client/src/client/proof_server.rs
+++ b/ethereum/light-client/src/client/proof_server.rs
@@ -69,12 +69,12 @@ impl ProofServerClient {
     pub(crate) async fn prove_committee_change(
         &self,
         proving_mode: ProvingMode,
-        store: LightClientStore,
+        store: Box<LightClientStore>,
         update: Update,
     ) -> Result<ProofType, ClientError> {
         let url = format!("http://{}/committee/proof", self.address);
 
-        let inputs = CommitteeChangeIn::new(store, update);
+        let inputs = CommitteeChangeIn::new(*store, update);
         let request = Request::ProveCommitteeChange(Box::new((proving_mode, inputs)));
 
         let response = self
@@ -139,13 +139,13 @@ impl ProofServerClient {
     pub(crate) async fn prove_storage_inclusion(
         &self,
         proving_mode: ProvingMode,
-        store: LightClientStore,
+        store: Box<LightClientStore>,
         update: Update,
         eip1186_proof: EIP1186Proof,
     ) -> Result<ProofType, ClientError> {
         let url = format!("http://{}/inclusion/proof", self.address);
 
-        let inputs = StorageInclusionIn::new(store, update, eip1186_proof);
+        let inputs = StorageInclusionIn::new(*store, update, eip1186_proof);
         let request = Request::ProveInclusion(Box::new((proving_mode, inputs)));
 
         let response = self


### PR DESCRIPTION
This PR fixes the Ethereum Light Client by setting the `LightClientStore` in a `Box`, thus preventing an overflow in spawned threads.

It also fixes the endpoint to forward request to when the proof server is in `split` mode.