### PR TITLE
feat: proper docker publish flow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,5 @@
-# Source: https://raw.githubusercontent.com/foundry-rs/foundry/master/.github/workflows/docker-publish.yml
-name: docker
+#
+name: Create and publish a Docker image
 
 on:
   workflow_dispatch:
@@ -7,76 +7,83 @@ on:
       light-client:
         description: 'aptos or ethereum'
         type: choice
+        required: true
         options:
           - aptos
           - ethereum
+      version:
+        description: "Image version"
+        required: true
+        type: string
 
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+  packages: write
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: "ghcr.io"
+  NAMESPACE: "argumentcomputer"
+  IMAGE_NAME: "proof-server"
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  container:
+  build-and-push-image:
     runs-on: ubuntu-latest
-    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
-      id-token: write
-      packages: write
       contents: read
-    timeout-minutes: 120
+      packages: write
+      attestations: write
+      id-token: write
+      #
     steps:
       - name: Checkout repository
-        id: checkout
         uses: actions/checkout@v4
-
-      - name: Install Docker BuildX
-        uses: docker/setup-buildx-action@v2
-        id: buildx
-        with:
-          install: true
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        # Ensure this doesn't trigger on PR's
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.REPO_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: "argumentcomputer/${{ inputs.light-client }}"
-
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
       # Creates an additional 'latest'
       - name: Finalize Docker Metadata
         id: docker_tagging
         run: |
           echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
-          echo "docker_tags=argumentcomputer/${{ inputs.light-client }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-
+          echo "docker_tags=${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}:${{inputs.version}}" >> $GITHUB_OUTPUT
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata
         run: |
           echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
           echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
-
-      # Build and push Docker image
-      # https://github.com/docker/build-push-action
-      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             LIGHT_CLIENT=${{ inputs.light-client }}
+          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,13 @@
+# This workflow is used to build and publish docker images for the proof servers
+# of our Light Clients. It is triggered manually and requires the user to provide
+# the Light Client and the version of the image to be published.
 #
+# The workflow can be triggered here: https://github.com/argumentcomputer/zk-light-clients/actions/workflows/docker-publish.yml
+#
+# The workflow is configured to run on the latest version of Ubuntu, and it uses
+# the `docker/build-push-action` action to build the image and push it to the
+# GitHub Container Registry. The image is tagged with the Light Client and the
+# version provided by the user.
 name: Create and publish a Docker image
 
 on:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
         id: docker_tagging
         run: |
           echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
-          echo "docker_tags=${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}:${{inputs.version}}" >> $GITHUB_OUTPUT
+          echo "docker_tags=${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}-proof-server:${{inputs.version}}" >> $GITHUB_OUTPUT
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,9 +41,21 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Set up Docker Buildx for better layer caching
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # Use Docker layer caching for faster builds
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,7 +63,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
       # Creates an additional 'latest'
@@ -70,7 +82,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,7 +92,7 @@ jobs:
           tags: ${{ steps.docker_tagging.outputs.docker_tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see the "[attestation docs](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,6 +84,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ inputs.light-client }}-proof-server
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This PR updates our docker publish flow so that we can upload our images as package of the repository.

For now the image has to be run on top of the desired branch to use for the image publication and the tag for the image is a manual input.

The workflow could be upgraded later on to trigger on commit merge on `release` branches, and have manual trigger for `:latest` images on `dev`. 

Successful run Aptos: 
  - Workflow: https://github.com/argumentcomputer/zk-light-clients/actions/runs/10831327079
  - Image: https://github.com/argumentcomputer/zk-light-clients/pkgs/container/aptos-proof-server/272696912?tag=latest
Successful run Ethereum:
  - Workflow: https://github.com/argumentcomputer/zk-light-clients/actions/runs/10831330803
  - Image: https://github.com/argumentcomputer/zk-light-clients/pkgs/container/ethereum-proof-server/272697110?tag=latest
