### PR TITLE
feat: kadena lc graph

### DIFF
--- a/kadena/core/src/types/adjacent.rs
+++ b/kadena/core/src/types/adjacent.rs
@@ -9,16 +9,14 @@ use crate::types::U16_BYTES_LENGTH;
 /// Size in bytes of the value for the adjacent parent. Contains the
 /// length of the adjacent parent record and the adjacent parent
 /// record itself.
-pub const ADJACENTS_RAW_BYTES_LENGTH: usize =
-    U16_BYTES_LENGTH + ADJACENT_RECORD_RAW_BYTES_LENGTH;
+pub const ADJACENTS_RAW_BYTES_LENGTH: usize = U16_BYTES_LENGTH + ADJACENT_RECORD_RAW_BYTES_LENGTH;
 
 /// Size in bytes of the adjacent parent record (without length prefix).
 pub const ADJACENT_RECORD_RAW_BYTES_LENGTH: usize =
     TWENTY_CHAIN_GRAPH_DEGREE * ADJACENT_PARENT_RAW_BYTES_LENGTH;
 
 /// Size in bytes of an entry in the the adjacent parent record.
-pub const ADJACENT_PARENT_RAW_BYTES_LENGTH: usize =
-    CHAIN_BYTES_LENGTH + DIGEST_BYTES_LENGTH;
+pub const ADJACENT_PARENT_RAW_BYTES_LENGTH: usize = CHAIN_BYTES_LENGTH + DIGEST_BYTES_LENGTH;
 
 /// Number of adjacent parents per block.
 pub const ADJACENT_RECORD_PER_BLOCK: usize = TWENTY_CHAIN_GRAPH_DEGREE;

--- a/kadena/core/src/types/adjacent.rs
+++ b/kadena/core/src/types/adjacent.rs
@@ -2,19 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::crypto::hash::DIGEST_BYTES_LENGTH;
+use crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE;
 use crate::types::header::chain::CHAIN_BYTES_LENGTH;
 use crate::types::U16_BYTES_LENGTH;
 
 /// Size in bytes of the value for the adjacent parent. Contains the
 /// length of the adjacent parent record and the adjacent parent
 /// record itself.
-pub const ADJACENTS_RAW_BYTES_LENGTH: usize = 110;
+pub const ADJACENTS_RAW_BYTES_LENGTH: usize =
+    U16_BYTES_LENGTH + ADJACENT_RECORD_RAW_BYTES_LENGTH;
 
-/// Size in bytes of the adjacent parent record.
-pub const ADJACENT_RECORD_RAW_BYTES_LENGTH: usize = 108;
+/// Size in bytes of the adjacent parent record (without length prefix).
+pub const ADJACENT_RECORD_RAW_BYTES_LENGTH: usize =
+    TWENTY_CHAIN_GRAPH_DEGREE * ADJACENT_PARENT_RAW_BYTES_LENGTH;
+
+/// Size in bytes of an entry in the the adjacent parent record.
+pub const ADJACENT_PARENT_RAW_BYTES_LENGTH: usize =
+    CHAIN_BYTES_LENGTH + DIGEST_BYTES_LENGTH;
 
 /// Number of adjacent parents per block.
-pub const ADJACENT_RECORD_PER_BLOCK: usize = 3;
+pub const ADJACENT_RECORD_PER_BLOCK: usize = TWENTY_CHAIN_GRAPH_DEGREE;
 
 /// Represent an adjacent parent in raw form for a Kadena block.
 pub struct AdjacentParentRaw {

--- a/kadena/core/src/types/error.rs
+++ b/kadena/core/src/types/error.rs
@@ -94,4 +94,6 @@ pub enum ValidationError {
     },
     #[error("Missing parent hash in the chain block header list at index {index}")]
     MissingParentHeader { index: usize },
+    #[error("Error in adjacent parent chain records at layer height {layer}, chain {chain}")]
+    InvalidAdjacentChainRecords { chain: usize, layer: usize },
 }

--- a/kadena/core/src/types/graph.rs
+++ b/kadena/core/src/types/graph.rs
@@ -1,22 +1,31 @@
-/// ! THIS MODULE MUST BE UPDATED IF THE CHAIN GRAPH DEGREE CHANGES.
-/// !
-/// ! The fact that this is a constant means that the code in this and any derived
-/// ! module can only be used with headers which have the same chain graph degree.
+// Copyright (c) Argument Computer Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module MUST be updated if the chain graph degree changes.
+//!
+//! A graph degree change also requires a change in the following methods:
+//! - [`crate::types::header::chain::KadenaHeaderRaw::header_root`]
+//! - [`crate::types::header::layer::ChainwebLayerHeader::verify`]
+//!
+//!
+//! The fact that this is a constant means that the code in this and any derived
+//! module can only be used with headers which have the same chain graph degree.
 
 /// The degree of the chain graph. This the number of adjacent parents for
 /// each block header.
 pub const TWENTY_CHAIN_GRAPH_DEGREE: usize = 3;
 pub const TWENTY_CHAIN_GRAPH_ORDER: usize = 20;
 
-pub type TwentyChainGraphType = 
-    [[u16; TWENTY_CHAIN_GRAPH_DEGREE]; TWENTY_CHAIN_GRAPH_ORDER];
+pub type TwentyChainGraphType = [[u32; TWENTY_CHAIN_GRAPH_DEGREE]; TWENTY_CHAIN_GRAPH_ORDER];
 
+/// The chain graph for the 20-chain network, sorted by chain ID, then
+/// from the lowest chain ID to the highest parent chain ID.
 pub const TWENTY_CHAIN_GRAPH: TwentyChainGraphType = [
-    [10, 15, 5],
-    [11, 16, 6],
-    [12, 17, 7],
-    [13, 18, 8],
-    [14, 19, 9],
+    [5, 10, 15],
+    [6, 11, 16],
+    [7, 12, 17],
+    [8, 13, 18],
+    [9, 14, 19],
     [0, 7, 8],
     [1, 8, 9],
     [2, 5, 9],
@@ -24,12 +33,12 @@ pub const TWENTY_CHAIN_GRAPH: TwentyChainGraphType = [
     [4, 6, 7],
     [0, 11, 19],
     [1, 10, 12],
-    [11, 13, 2],
-    [12, 14, 3],
-    [13, 15, 4],
+    [2, 11, 13],
+    [3, 12, 14],
+    [4, 13, 15],
     [0, 14, 16],
     [1, 15, 17],
-    [16, 18, 2],
-    [17, 19, 3],
-    [10, 18, 4],
+    [2, 16, 18],
+    [3, 17, 19],
+    [4, 10, 18],
 ];

--- a/kadena/core/src/types/graph.rs
+++ b/kadena/core/src/types/graph.rs
@@ -1,0 +1,35 @@
+/// ! THIS MODULE MUST BE UPDATED IF THE CHAIN GRAPH DEGREE CHANGES.
+/// !
+/// ! The fact that this is a constant means that the code in this and any derived
+/// ! module can only be used with headers which have the same chain graph degree.
+
+/// The degree of the chain graph. This the number of adjacent parents for
+/// each block header.
+pub const TWENTY_CHAIN_GRAPH_DEGREE: usize = 3;
+pub const TWENTY_CHAIN_GRAPH_ORDER: usize = 20;
+
+pub type TwentyChainGraphType = 
+    [[u16; TWENTY_CHAIN_GRAPH_DEGREE]; TWENTY_CHAIN_GRAPH_ORDER];
+
+pub const TWENTY_CHAIN_GRAPH: TwentyChainGraphType = [
+    [10, 15, 5],
+    [11, 16, 6],
+    [12, 17, 7],
+    [13, 18, 8],
+    [14, 19, 9],
+    [0, 7, 8],
+    [1, 8, 9],
+    [2, 5, 9],
+    [3, 5, 6],
+    [4, 6, 7],
+    [0, 11, 19],
+    [1, 10, 12],
+    [11, 13, 2],
+    [12, 14, 3],
+    [13, 15, 4],
+    [0, 14, 16],
+    [1, 15, 17],
+    [16, 18, 2],
+    [17, 19, 3],
+    [10, 18, 4],
+];

--- a/kadena/core/src/types/header/chain.rs
+++ b/kadena/core/src/types/header/chain.rs
@@ -10,19 +10,21 @@ use crate::merkle::{
     CHAINWEB_VERSION_TAG, CHAIN_ID_TAG, EPOCH_START_TIME_TAG, FEATURE_FLAGS_TAG, HASH_TARGET_TAG,
 };
 use crate::types::adjacent::{
-    AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH,
+    self, AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH, ADJACENT_PARENT_RAW_BYTES_LENGTH
 };
 use crate::types::error::{TypesError, ValidationError};
 use crate::types::utils::extract_fixed_bytes;
-use crate::types::{U32_BYTES_LENGTH, U64_BYTES_LENGTH};
+use crate::types::{U16_BYTES_LENGTH, U32_BYTES_LENGTH, U64_BYTES_LENGTH};
+use crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE;
 use anyhow::Result;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use getset::Getters;
+use sha2::digest::consts::U16;
 
 /// Size in bytes of a Kadena header represented as a base64 string
-pub const RAW_HEADER_BYTES_LEN: usize = 424;
+pub const RAW_HEADER_BYTES_LEN: usize = (RAW_HEADER_DECODED_BYTES_LENGTH * 4 + 2) / 3;
 
 ///  Size in bytes of a Kadena header represented as a byte array
 pub const RAW_HEADER_DECODED_BYTES_LENGTH: usize = FLAGS_BYTES_LENGTH
@@ -206,7 +208,7 @@ impl KadenaHeaderRaw {
     ///
     /// # Returns
     ///
-    /// The bytes of  the Kadena header encoded as a base64. .
+    /// The bytes of the Kadena header encoded as a base64. .
     pub fn to_base64(&self) -> Vec<u8> {
         let bytes = self.to_bytes();
         URL_SAFE_NO_PAD.encode(&bytes).into_bytes()
@@ -237,17 +239,18 @@ impl KadenaHeaderRaw {
     ///
     /// The root hash of the header.
     pub fn header_root(&self) -> Result<HashValue, CryptoError> {
-        let adjacent_hashes: Vec<[u8; 32]> = vec![
-            self.adjacents[6..6 + DIGEST_BYTES_LENGTH]
+
+        let mut adjacent_hashes: Vec<[u8; 32]> = Vec::with_capacity(TWENTY_CHAIN_GRAPH_DEGREE);
+        for i in 0..TWENTY_CHAIN_GRAPH_DEGREE {
+            let start = U16_BYTES_LENGTH
+                + i * ADJACENT_PARENT_RAW_BYTES_LENGTH
+                + CHAIN_BYTES_LENGTH;
+            let end = start + DIGEST_BYTES_LENGTH;
+            adjacent_hashes.push(self.adjacents[start..end]
                 .try_into()
-                .expect("Should be able to convert adjacent hash to fixed length array"),
-            self.adjacents[42..42 + DIGEST_BYTES_LENGTH]
-                .try_into()
-                .expect("Should be able to convert adjacent hash to fixed length array"),
-            self.adjacents[78..78 + DIGEST_BYTES_LENGTH]
-                .try_into()
-                .expect("Should be able to convert adjacent hash to fixed length array"),
-        ];
+                .expect("Should be able to convert adjacent hash to fixed length array")
+            );
+        }
 
         // Bottom leaves
         let hashes = vec![

--- a/kadena/core/src/types/header/chain.rs
+++ b/kadena/core/src/types/header/chain.rs
@@ -10,12 +10,13 @@ use crate::merkle::{
     CHAINWEB_VERSION_TAG, CHAIN_ID_TAG, EPOCH_START_TIME_TAG, FEATURE_FLAGS_TAG, HASH_TARGET_TAG,
 };
 use crate::types::adjacent::{
-    AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH, ADJACENT_PARENT_RAW_BYTES_LENGTH
+    AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH,
+    ADJACENT_PARENT_RAW_BYTES_LENGTH,
 };
 use crate::types::error::{TypesError, ValidationError};
+use crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE;
 use crate::types::utils::extract_fixed_bytes;
 use crate::types::{U16_BYTES_LENGTH, U32_BYTES_LENGTH, U64_BYTES_LENGTH};
-use crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE;
 use anyhow::Result;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -243,16 +244,15 @@ impl KadenaHeaderRaw {
     /// When the  chain graph degree changes along with the [`crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE`]
     /// constant this method should be updated.
     pub fn header_root(&self) -> Result<HashValue, CryptoError> {
-
         let mut adjacent_hashes: Vec<[u8; 32]> = Vec::with_capacity(TWENTY_CHAIN_GRAPH_DEGREE);
         for i in 0..TWENTY_CHAIN_GRAPH_DEGREE {
-            let start = U16_BYTES_LENGTH
-                + i * ADJACENT_PARENT_RAW_BYTES_LENGTH
-                + CHAIN_BYTES_LENGTH;
+            let start =
+                U16_BYTES_LENGTH + i * ADJACENT_PARENT_RAW_BYTES_LENGTH + CHAIN_BYTES_LENGTH;
             let end = start + DIGEST_BYTES_LENGTH;
-            adjacent_hashes.push(self.adjacents[start..end]
-                .try_into()
-                .expect("Should be able to convert adjacent hash to fixed length array")
+            adjacent_hashes.push(
+                self.adjacents[start..end]
+                    .try_into()
+                    .expect("Should be able to convert adjacent hash to fixed length array"),
             );
         }
 

--- a/kadena/core/src/types/header/chain.rs
+++ b/kadena/core/src/types/header/chain.rs
@@ -10,7 +10,7 @@ use crate::merkle::{
     CHAINWEB_VERSION_TAG, CHAIN_ID_TAG, EPOCH_START_TIME_TAG, FEATURE_FLAGS_TAG, HASH_TARGET_TAG,
 };
 use crate::types::adjacent::{
-    self, AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH, ADJACENT_PARENT_RAW_BYTES_LENGTH
+    AdjacentParentRecord, AdjacentParentRecordRaw, ADJACENTS_RAW_BYTES_LENGTH, ADJACENT_PARENT_RAW_BYTES_LENGTH
 };
 use crate::types::error::{TypesError, ValidationError};
 use crate::types::utils::extract_fixed_bytes;
@@ -21,7 +21,6 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use getset::Getters;
-use sha2::digest::consts::U16;
 
 /// Size in bytes of a Kadena header represented as a base64 string
 pub const RAW_HEADER_BYTES_LEN: usize = (RAW_HEADER_DECODED_BYTES_LENGTH * 4 + 2) / 3;
@@ -238,6 +237,11 @@ impl KadenaHeaderRaw {
     /// # Returns
     ///
     /// The root hash of the header.
+    ///
+    /// # Notes
+    ///
+    /// When the  chain graph degree changes along with the [`crate::types::graph::TWENTY_CHAIN_GRAPH_DEGREE`]
+    /// constant this method should be updated.
     pub fn header_root(&self) -> Result<HashValue, CryptoError> {
 
         let mut adjacent_hashes: Vec<[u8; 32]> = Vec::with_capacity(TWENTY_CHAIN_GRAPH_DEGREE);

--- a/kadena/core/src/types/mod.rs
+++ b/kadena/core/src/types/mod.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Argument Computer Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod graph;
 pub mod adjacent;
 pub mod error;
+pub mod graph;
 pub mod header;
 pub mod utils;
 

--- a/kadena/core/src/types/mod.rs
+++ b/kadena/core/src/types/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Argument Computer Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod graph;
 pub mod adjacent;
 pub mod error;
 pub mod header;


### PR DESCRIPTION
This PR superseds #239. 

It use it as a base to leverage the new `graph` module to verify adjacent record chain IDs in `ChainwebLayerHeader::verify`.

I have also sorted the chain IDs in `TWENTY_CHAIN_GRAPH` so that we don't have to do so while computing.

cc/ @larskuhtz 