### PR TITLE
feat: kadena fetch payload

### DIFF
--- a/kadena/light-client/src/bin/client.rs
+++ b/kadena/light-client/src/bin/client.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
         .await
         .unwrap();
 
-    let request_key = payload.get_transaction_output_key(0)?;
+    let request_key = payload.get_transaction_request_key(0)?;
 
     let spv = client.get_spv(0, request_key).await?;
 

--- a/kadena/light-client/src/bin/client.rs
+++ b/kadena/light-client/src/bin/client.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use kadena_lc::client::Client;
 use kadena_lc::proofs::ProvingMode;
 use kadena_lc_core::crypto::hash::HashValue;
+use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
 use std::env;
 use std::sync::Arc;
 
@@ -48,35 +49,59 @@ async fn main() -> Result<()> {
         proof_server_address.as_str(),
     );
 
+    // Test verification for the longest chain
     let kadena_headers = client
         .get_layer_block_headers(TARGET_BLOCK, BLOCK_WINDOW)
         .await?;
+
+    let (first_hash, target_hash, verified_confirmation_work) =
+        ChainwebLayerHeader::verify(&kadena_headers)?;
+
+    let confirmation_work = ChainwebLayerHeader::cumulative_produced_work(
+        kadena_headers[kadena_headers.len() / 2..kadena_headers.len() - 1].to_vec(),
+    )
+    .expect("Should be able to calculate cumulative work");
+
+    assert_eq!(confirmation_work, verified_confirmation_work,);
+    assert_eq!(
+        first_hash,
+        kadena_headers
+            .first()
+            .expect("Should have a first header")
+            .header_root()
+            .expect("Should have a header root"),
+    );
+    assert_eq!(
+        target_hash,
+        kadena_headers[kadena_headers.len() / 2]
+            .header_root()
+            .expect("Should have a header root"),
+    );
 
     let target_block = kadena_headers
         .get(kadena_headers.len() / 2)
         .unwrap()
         .clone();
-    // Fetch SPV proof for the target block height of chain 0
-    // Fetching SPV for request key "Xe7GN8pA4paS-vF0L4EOTkcBj_K4u72D6xdKg7E724M"
-    // https://explorer.chainweb.com/mainnet/txdetail/Xe7GN8pA4paS-vF0L4EOTkcBj_K4u72D6xdKg7E724M
-    let spv = client
-        .get_spv(
+
+    let payload = client
+        .get_payload(
             0,
-            String::from("Xe7GN8pA4paS-vF0L4EOTkcBj_K4u72D6xdKg7E724M"),
+            HashValue::new(*target_block.chain_headers().first().unwrap().payload()),
         )
         .await
         .unwrap();
 
-    println!("{:?}", spv.subject().input().as_bytes().len());
+    let request_key = payload.get_transaction_output_key(0)?;
 
-    println!("BlockHeader Hash");
-    println!(
-        "{}",
-        spv.verify(&HashValue::new(
-            *target_block.chain_headers().first().unwrap().hash()
-        ))
-        .unwrap()
-    );
+    let spv = client.get_spv(0, request_key).await?;
+
+    spv.verify(&HashValue::new(
+        *target_block
+            .chain_headers()
+            .first()
+            .expect("Should have a header root")
+            .hash(),
+    ))?;
 
     Ok(())
 }

--- a/kadena/light-client/src/client/mod.rs
+++ b/kadena/light-client/src/client/mod.rs
@@ -15,6 +15,7 @@ use crate::client::chainweb::ChainwebClient;
 use crate::client::error::ClientError;
 use crate::client::proof_server::ProofServerClient;
 use crate::proofs::{ProofType, ProvingMode};
+use crate::types::chainweb::PayloadResponse;
 use kadena_lc_core::crypto::hash::HashValue;
 use kadena_lc_core::merkle::spv::Spv;
 use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
@@ -166,5 +167,23 @@ impl Client {
     /// A boolean indicating whether the proof is valid.
     pub async fn verify_spv(&self, proof: ProofType) -> Result<bool, ClientError> {
         self.proof_server_client.verify_spv(proof).await
+    }
+
+    /// Get the payload for the given chain and payload hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `chain` - The chain to get the payload from.
+    /// * `payload_hash` - The payload hash to get the payload for.
+    ///
+    /// # Returns
+    ///
+    /// The payload.
+    pub async fn get_payload(
+        &self,
+        chain: u32,
+        payload_hash: HashValue,
+    ) -> Result<PayloadResponse, ClientError> {
+        self.chainweb_client.get_payload(chain, payload_hash).await
     }
 }

--- a/kadena/light-client/src/types/chainweb.rs
+++ b/kadena/light-client/src/types/chainweb.rs
@@ -62,7 +62,7 @@ impl TryInto<Spv> for SpvResponse {
     }
 }
 
-/// Response received while querying a  Payload from a Chainweb
+/// Response received while querying a Payload from a Chainweb
 /// node.
 #[derive(Clone, Debug, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]

--- a/kadena/light-client/src/types/chainweb.rs
+++ b/kadena/light-client/src/types/chainweb.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Argument Computer Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{anyhow, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use getset::Getters;
 use kadena_lc_core::merkle::proof::MerkleProof;
 use kadena_lc_core::merkle::spv::Spv;
 use kadena_lc_core::merkle::subject::Subject;
 use kadena_lc_core::types::error::TypesError;
 use kadena_lc_core::types::header::chain::KadenaHeaderRaw;
 use serde::Deserialize;
+
+const REQUEST_KEY_PROPERTY: &str = "reqKey";
 
 /// Response received while querying block headers from a Chainweb
 /// node.
@@ -29,7 +35,7 @@ impl TryInto<Vec<KadenaHeaderRaw>> for BlockHeaderResponse {
     }
 }
 
-/// Response received while querying a SPV proof from a Chainweb
+/// Response received while querying an SPV proof from a Chainweb
 /// node.
 #[derive(Clone, Debug, Deserialize)]
 pub struct SpvResponse {
@@ -53,5 +59,56 @@ impl TryInto<Spv> for SpvResponse {
         let subject = Subject::new(self.subject.input);
 
         Ok(Spv::new(self.algorithm, self.chain, object, subject))
+    }
+}
+
+/// Response received while querying a  Payload from a Chainweb
+/// node.
+#[derive(Clone, Debug, Deserialize, Getters)]
+#[serde(rename_all = "camelCase")]
+#[getset(get = "pub")]
+pub struct PayloadResponse {
+    coinbase: String,
+    miner_data: String,
+    outputs_hash: String,
+    payload_hash: String,
+    transactions: Vec<Vec<String>>,
+    transactions_hash: String,
+}
+
+impl PayloadResponse {
+    /// Get the transaction output key for the given transaction index.
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_index` - The index of the transaction.
+    ///
+    /// # Returns
+    ///
+    /// The transaction output key.
+    pub fn get_transaction_output_key(&self, transaction_index: usize) -> Result<String> {
+        let output_bytes = URL_SAFE_NO_PAD
+            .decode(
+                self.transactions()
+                    .get(transaction_index)
+                    .ok_or_else(|| anyhow!("Transaction index out of bounds"))?
+                    .get(1)
+                    .ok_or_else(|| anyhow!("Transaction output not found"))?
+                    .as_bytes(),
+            )
+            .map_err(|err| anyhow!("Error decoding transaction output: {}", err))?;
+
+        let json_value = serde_json::from_slice::<serde_json::Value>(&output_bytes)
+            .map_err(|err| anyhow!("Error deserializing transaction output: {}", err))?;
+
+        json_value
+            .get(REQUEST_KEY_PROPERTY)
+            .ok_or_else(|| anyhow!("Request key not found in transaction output"))
+            .and_then(|value| {
+                value
+                    .as_str()
+                    .ok_or_else(|| anyhow!("Request key is not a string"))
+            })
+            .map(|value| value.to_string())
     }
 }

--- a/kadena/light-client/src/types/chainweb.rs
+++ b/kadena/light-client/src/types/chainweb.rs
@@ -77,7 +77,7 @@ pub struct PayloadResponse {
 }
 
 impl PayloadResponse {
-    /// Get the transaction output key for the given transaction index.
+    /// Get the transaction request key for the given transaction index.
     ///
     /// # Arguments
     ///
@@ -85,8 +85,8 @@ impl PayloadResponse {
     ///
     /// # Returns
     ///
-    /// The transaction output key.
-    pub fn get_transaction_output_key(&self, transaction_index: usize) -> Result<String> {
+    /// The transaction request key.
+    pub fn get_transaction_request_key(&self, transaction_index: usize) -> Result<String> {
         let output_bytes = URL_SAFE_NO_PAD
             .decode(
                 self.transactions()


### PR DESCRIPTION
This PR adds a method to fetch paylaod for a block based on the payload  hash its header contains. This let us access its request key, thus querying an SPV.

## Changelog

- Added a method to `ChainwebClient` to fetch a payload data based on its hash
- Created `PayloadResponse` to deserialize the response of the call, along with one method to extract the request key for a transaction at a given index.