### PR TITLE
feat: kadena benchmarks

### DIFF
--- a/kadena/docs/src/benchmark/overview.md
+++ b/kadena/docs/src/benchmark/overview.md
@@ -10,3 +10,33 @@ Due to the SNARK compression, the SNARK proofs take longer to generate and requi
 
 Currently, the Sphinx prover is **CPU-only**, and there is no GPU acceleration integrated yet. We are working on
 integrating future work for GPU acceleration as soon as we can to improve the overall proving time.
+
+## Current Results
+
+The current results are based on a list of Layer Block headers of 7 elements.
+
+### Longest chain
+
+Cycles:  **43 543 881**
+
+SNARK time in milliseconds:
+
+```json
+{
+  "proving_time": 1008628,
+  "verification_time": 4
+}
+```
+
+### SPV
+
+Cycles: **43 949 106**
+
+SNARK time in milliseconds:
+
+```json
+{
+  "proving_time": 1015826,
+  "verification_time": 5
+}
+```

--- a/kadena/light-client/Cargo.toml
+++ b/kadena/light-client/Cargo.toml
@@ -43,3 +43,11 @@ path = "src/bin/client.rs"
 [[bin]]
 name = "proof_server"
 path = "src/bin/proof_server.rs"
+
+[[bench]]
+name = "longest_chain"
+harness = false
+
+[[bench]]
+name = "spv"
+harness = false

--- a/kadena/light-client/Makefile
+++ b/kadena/light-client/Makefile
@@ -1,0 +1,15 @@
+.PHONY: benchmark bench-ci
+
+benchmark:
+	@read -p "Enter benchmark name: " bench; \
+	RUSTFLAGS="-C target-cpu=native -C opt-level=3" \
+	SHARD_SIZE=4194304 \
+	SHARD_BATCH_SIZE=0 \
+	SHARD_CHUNKING_MULTIPLIER=256 \
+	RECONSTRUCT_COMMITMENTS=false \
+	cargo bench --features kadena --bench $$bench
+
+BENCH ?= committee_change
+
+bench-ci:
+	cargo bench --features kadena --bench $(BENCH)

--- a/kadena/light-client/Makefile
+++ b/kadena/light-client/Makefile
@@ -9,7 +9,7 @@ benchmark:
 	RECONSTRUCT_COMMITMENTS=false \
 	cargo bench --features kadena --bench $$bench
 
-BENCH ?= committee_change
+BENCH ?= longest_chain
 
 bench-ci:
 	cargo bench --features kadena --bench $(BENCH)

--- a/kadena/light-client/benches/longest_chain.rs
+++ b/kadena/light-client/benches/longest_chain.rs
@@ -1,0 +1,62 @@
+use kadena_lc::proofs::longest_chain::{LongestChainIn, LongestChainProver};
+use kadena_lc::proofs::{Prover, ProvingMode};
+use kadena_lc_core::test_utils::get_layer_block_headers;
+use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
+use serde::Serialize;
+use std::env;
+use std::time::Instant;
+
+struct BenchmarkAssets {
+    prover: LongestChainProver,
+    layer_headers: Vec<ChainwebLayerHeader>,
+}
+
+impl BenchmarkAssets {
+    fn generate() -> Self {
+        let test_assets = get_layer_block_headers();
+
+        Self {
+            prover: LongestChainProver::new(),
+            layer_headers: test_assets,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchResults {
+    proving_time: u128,
+    verification_time: u128,
+}
+
+fn main() {
+    let mode_str: String = env::var("MODE").unwrap_or_else(|_| "STARK".into());
+    let mode = ProvingMode::try_from(mode_str.as_str()).expect("MODE should be STARK or SNARK");
+
+    let benchmark_assets = BenchmarkAssets::generate();
+
+    let inputs = LongestChainIn::new(benchmark_assets.layer_headers.clone());
+
+    // Generate proof
+    let start_proving = Instant::now();
+    let proof = benchmark_assets
+        .prover
+        .prove(&inputs, mode)
+        .expect("Failed to prove longest chain");
+    let proving_time = start_proving.elapsed();
+
+    // Verify proof
+    let start_verifying = Instant::now();
+    benchmark_assets
+        .prover
+        .verify(&proof)
+        .expect("Failed to verify longest chain proof");
+    let verifying_time = start_verifying.elapsed();
+
+    // Print results
+    let results = BenchResults {
+        proving_time: proving_time.as_millis(),
+        verification_time: verifying_time.as_millis(),
+    };
+
+    println!("{}", serde_json::to_string(&results).unwrap());
+}

--- a/kadena/light-client/benches/spv.rs
+++ b/kadena/light-client/benches/spv.rs
@@ -2,7 +2,7 @@ use kadena_lc::proofs::spv::{SpvIn, SpvProver};
 use kadena_lc::proofs::{Prover, ProvingMode};
 use kadena_lc_core::crypto::hash::HashValue;
 use kadena_lc_core::merkle::spv::Spv;
-use kadena_lc_core::test_utils::{get_layer_block_headers, get_test_assets};
+use kadena_lc_core::test_utils::get_test_assets;
 use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
 use serde::Serialize;
 use std::env;
@@ -21,7 +21,7 @@ impl BenchmarkAssets {
 
         Self {
             prover: SpvProver::new(),
-            layer_headers: test_assets.layer_headers().to_vec(),
+            layer_headers: test_assets.layer_headers().clone(),
             spv: test_assets.spv().clone(),
             expected_root: *test_assets.expected_root(),
         }

--- a/kadena/light-client/benches/spv.rs
+++ b/kadena/light-client/benches/spv.rs
@@ -1,0 +1,72 @@
+use kadena_lc::proofs::spv::{SpvIn, SpvProver};
+use kadena_lc::proofs::{Prover, ProvingMode};
+use kadena_lc_core::crypto::hash::HashValue;
+use kadena_lc_core::merkle::spv::Spv;
+use kadena_lc_core::test_utils::{get_layer_block_headers, get_test_assets};
+use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
+use serde::Serialize;
+use std::env;
+use std::time::Instant;
+
+struct BenchmarkAssets {
+    prover: SpvProver,
+    layer_headers: Vec<ChainwebLayerHeader>,
+    spv: Spv,
+    expected_root: HashValue,
+}
+
+impl BenchmarkAssets {
+    fn generate() -> Self {
+        let test_assets = get_test_assets();
+
+        Self {
+            prover: SpvProver::new(),
+            layer_headers: test_assets.layer_headers().to_vec(),
+            spv: test_assets.spv().clone(),
+            expected_root: *test_assets.expected_root(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchResults {
+    proving_time: u128,
+    verification_time: u128,
+}
+
+fn main() {
+    let mode_str: String = env::var("MODE").unwrap_or_else(|_| "STARK".into());
+    let mode = ProvingMode::try_from(mode_str.as_str()).expect("MODE should be STARK or SNARK");
+
+    let benchmark_assets = BenchmarkAssets::generate();
+
+    let inputs = SpvIn::new(
+        benchmark_assets.layer_headers.clone(),
+        benchmark_assets.spv.clone(),
+        benchmark_assets.expected_root,
+    );
+
+    // Generate proof
+    let start_proving = Instant::now();
+    let proof = benchmark_assets
+        .prover
+        .prove(&inputs, mode)
+        .expect("Failed to prove longest chain");
+    let proving_time = start_proving.elapsed();
+
+    // Verify proof
+    let start_verifying = Instant::now();
+    benchmark_assets
+        .prover
+        .verify(&proof)
+        .expect("Failed to verify longest chain proof");
+    let verifying_time = start_verifying.elapsed();
+
+    // Print results
+    let results = BenchResults {
+        proving_time: proving_time.as_millis(),
+        verification_time: verifying_time.as_millis(),
+    };
+
+    println!("{}", serde_json::to_string(&results).unwrap());
+}

--- a/kadena/light-client/src/client/mod.rs
+++ b/kadena/light-client/src/client/mod.rs
@@ -18,7 +18,6 @@ use crate::proofs::{ProofType, ProvingMode};
 use crate::types::chainweb::PayloadResponse;
 use kadena_lc_core::crypto::hash::HashValue;
 use kadena_lc_core::merkle::spv::Spv;
-use kadena_lc_core::types::header::chain::KadenaHeaderRaw;
 use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
 
 pub(crate) mod chainweb;
@@ -186,25 +185,5 @@ impl Client {
         payload_hash: HashValue,
     ) -> Result<PayloadResponse, ClientError> {
         self.chainweb_client.get_payload(chain, payload_hash).await
-    }
-
-    /// Get the latest block header for the given chain.
-    ///
-    /// # Arguments
-    ///
-    /// * `chain` - The chain to get the latest block header from.
-    /// * `target_block` - The target block height.
-    ///
-    /// # Returns
-    ///
-    /// The latest block header.
-    pub async fn get_block_header(
-        &self,
-        chain: u32,
-        target_block: usize,
-    ) -> Result<KadenaHeaderRaw, ClientError> {
-        self.chainweb_client
-            .get_block_header(chain, target_block)
-            .await
     }
 }

--- a/kadena/light-client/src/client/mod.rs
+++ b/kadena/light-client/src/client/mod.rs
@@ -18,6 +18,7 @@ use crate::proofs::{ProofType, ProvingMode};
 use crate::types::chainweb::PayloadResponse;
 use kadena_lc_core::crypto::hash::HashValue;
 use kadena_lc_core::merkle::spv::Spv;
+use kadena_lc_core::types::header::chain::KadenaHeaderRaw;
 use kadena_lc_core::types::header::layer::ChainwebLayerHeader;
 
 pub(crate) mod chainweb;
@@ -185,5 +186,25 @@ impl Client {
         payload_hash: HashValue,
     ) -> Result<PayloadResponse, ClientError> {
         self.chainweb_client.get_payload(chain, payload_hash).await
+    }
+
+    /// Get the latest block header for the given chain.
+    ///
+    /// # Arguments
+    ///
+    /// * `chain` - The chain to get the latest block header from.
+    /// * `target_block` - The target block height.
+    ///
+    /// # Returns
+    ///
+    /// The latest block header.
+    pub async fn get_block_header(
+        &self,
+        chain: u32,
+        target_block: usize,
+    ) -> Result<KadenaHeaderRaw, ClientError> {
+        self.chainweb_client
+            .get_block_header(chain, target_block)
+            .await
     }
 }


### PR DESCRIPTION
> Note: #244 should be reviewed and merged before this is one is

This PR adds benchmarks for the two programs of the KDA LC.

The current results are the following:

### Longest chain

Cycles:  **43 543 881**

SNARK time in milliseconds:

```json
{
  "proving_time": 1008628,
  "verification_time": 4
}
```

### SPV

Cycles: **43 949 106**

SNARK time in milliseconds:

```json
{
  "proving_time": 1015826,
  "verification_time": 5
}
```