### PR TITLE
ci: Fix `release-pr.yml` version

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           repository: argumentcomputer/ci-workflows
           path: ci-workflows
-          ref: release-workflow
       - name: Add `programs/` subcrates to release
         run: |
           if [[ "${{ inputs.light-client }}" == "aptos" ]]; then


### PR DESCRIPTION
Switch to `ci-workflows` `main` as https://github.com/argumentcomputer/ci-workflows/pull/76 and https://github.com/argumentcomputer/ci-workflows/pull/77 were merged