### PR TITLE
ci: Categorize release commits in changelog

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -1,0 +1,52 @@
+{
+    "template": "#{{CHANGELOG}}",
+    "categories": [
+        {
+            "title": "## 🚀 Features",
+            "labels": [
+                "feat"
+            ]
+        },
+        {
+            "title": "## 🐛 Fixes",
+            "labels": [
+                "fix"
+            ]
+        },
+        {
+            "title": "## ⚡️ Performance",
+            "labels": [
+                "perf"
+            ]
+        },
+        {
+            "title": "## 🧪 Tests",
+            "labels": [
+                "test"
+            ]
+        },
+        {
+            "title": "## 📝 Docs",
+            "labels": [
+                "docs"
+            ]
+        },
+        {
+            "title": "## 🤖 CI",
+            "labels": [
+                "automated-issue",
+                "ci"
+            ]
+        },
+        {
+            "title": "## Other",
+            "labels": []
+        }
+    ],
+    "label_extractor": [
+        {
+            "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+            "target": "$1"
+        }
+    ]
+}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: PR Lint
+
+on:
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,6 +14,7 @@
 #   - Opens a release PR from `patch/<tag-prefix>-v<version>` to `release/<tag-prefix>-v<version>`
 #
 # When the PR is merged, the caller can then trigger a release from `ci-workflows/actions/tag-release`
+# NOTE: To get a rich changelog based on each commit prefix, merge without squashing. Otherwise, the changelog will only show the release PR
 # The PR branch can then be safely deleted, while the release branch should have a branch protection rule for historical preservation
 #
 # The `ci-workflows` release PR action can be found at https://github.com/argumentcomputer/ci-workflows/blob/main/.github/actions/release-pr/action.yml

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -44,32 +44,7 @@ jobs:
         with:
           repository: argumentcomputer/ci-workflows
           path: ci-workflows
-      # TODO: Refine changelog categories
-      - name: Create changelog config
-        run: |
-          cat << 'EOF' > config.json
-          {
-            "template": "#{{CHANGELOG}}",
-            "categories": [
-              {
-                  "title": "## Feature",
-                  "labels": ["feat", "feature"]
-              },
-              {
-                  "title": "## Fix",
-                  "labels": ["fix", "bug"]
-              },
-              {
-                  "title": "## 🤖 CI",
-                  "labels": ["automated-issue", "ci"]
-              },
-              {
-                  "title": "## Other",
-                  "labels": []
-              }
-            ]
-          }
-          EOF
+          ref: release-workflow
       - name: Get branch and version info
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -93,4 +68,4 @@ jobs:
           release-branch: ${{ env.RELEASE_BRANCH }}
           version: ${{ env.VERSION }}
           tag-prefix: ${{ env.LIGHT_CLIENT }}
-          changelog-config-file: ./config.json
+          changelog-config-file: ${{ github.workspace }}/.github/changelog-config.json

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           repository: argumentcomputer/ci-workflows
           path: ci-workflows
-          ref: release-workflow
       - name: Get branch and version info
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then


### PR DESCRIPTION
Adds a rich changelog to releases using Commit Mode in https://github.com/mikepenz/release-changelog-builder-action?tab=readme-ov-file#full-sample-%EF%B8%8F (see `Example Commit Mode w/ Configuration`). This uses a config file to extract commit prefixes for categorization in the final changelog, e.g. `feat`, `fix`, etc. ([sample changelog output](https://github.com/samuelburnham/zk-light-clients/releases/tag/aptos-v1.1.0))

> [!NOTE]
> Since we cherry-pick commits from `dev` and push them to the release PR branch, merging the PR will require creating a merge commit rather than squash-merging in order to preserve the individual commit history for the changelog builder action.

Also adds a PR title linter to ensure that commits are correctly categorized in the changelog. Note that the workflow runs on `pull_request_target`, which must exist in the target branch to trigger, so it will take effect after this PR merges.