### PR TITLE
ci: Stabilize Clippy job by using stable toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,8 +117,9 @@ jobs:
       - name: rustfmt
         run: cargo fmt --all --check
         working-directory: ${{ github.workspace }}/${{ matrix.package }}
+      # The stable toolchain is used to run clippy so as to not hit nightly errors
       - name: cargo clippy
-        run: cargo xclippy -D warnings
+        run: cargo +stable xclippy -D warnings
         working-directory: ${{ github.workspace }}/${{ matrix.package }}
       - name: Doctests
         if: ${{ matrix.package != 'fixture-generator'}}


### PR DESCRIPTION
- Updated the workflow configuration to use stable Rust toolchain for cargo clippy.
- Modified the run command in clippy job for better error avoidance.