### PR TITLE
feat: Update Sphinx-related security documentation

### DIFF
--- a/kadena/docs/src/design/security.md
+++ b/kadena/docs/src/design/security.md
@@ -5,13 +5,14 @@
 The [Sphinx](https://github.com/argumentcomputer/sphinx) prover is a fork of [SP1](https://github.com/succinctlabs/sp1)
 and as such inherits a lot from its security design. The current release of Sphinx (`dev`) has backported all the
 upstream security fixes as of SP1 `v1.0.8-testnet`. We will continue to update Sphinx with backports of upstream
-security fixes and subsequent updates to both Sphinx and the Light Client making them available as hotfixes.
+security fixes and subsequent updates to both Sphinx and the Light Client, making them available as hotfixes.
 
 In terms of Sphinx-specific changes that require special attention, here is a non-exhaustive list of Sphinx
-AIR chips used for pre-compiles that are either not present in upstream SP1, or have had non-trivial changes:
-- `FieldAddChip`, `FieldSubChip`, `FieldMulChip`: Chips for BLS12-381 Fp acceleration.
-- `QuadFieldAddChip`, `QuadFieldSubChip`, `QuadFieldMulChip`: Chips for BLS12-381 Fp2 acceleration.
-- `Bls12381G1DecompressChip`: Chip for decompressing BLS12-381 compressed G1 points.
-- `Secp256k1DecompressChip`: Chip for decompressing K256 compressed points.
+AIR chips used for precompiles that are either not present in upstream SP1, or have had non-trivial changes:
 
-There are some SP1 chips and pre-compiles that are not present in Sphinx, such as `Uint256MulChip`.
+- `Blake2sRoundChip`: Chip for the Blake2s hash function compression, as specified in [RFC 7693](https://datatracker.ietf.org/doc/html/rfc7693).
+- `Sha512CompressChip`, `Sha512ExtendChip`:Chips for the SHA-512 hash function compression.
+
+Notably, the Kadena light client does not use BLS12-381 related precompiles, such as field operations (`FieldAddChip`, `FieldSubChip`, `FieldMulChip`) or G1 decompression (`Bls12381G1DecompressChip`), neither does it use `Secp256k1DecompressChip`, a chip for decompressing K256 compressed points. Therefore, the light client’s proof does not depend on the correctness of these precompiles. 
+
+There are also some SP1 chips and precompiles that are not present in Sphinx, such as `Uint256MulChip`.

--- a/kadena/docs/src/design/security.md
+++ b/kadena/docs/src/design/security.md
@@ -11,7 +11,7 @@ In terms of Sphinx-specific changes that require special attention, here is a no
 AIR chips used for precompiles that are either not present in upstream SP1, or have had non-trivial changes:
 
 - `Blake2sRoundChip`: Chip for the Blake2s hash function compression, as specified in [RFC 7693](https://datatracker.ietf.org/doc/html/rfc7693).
-- `Sha512CompressChip`, `Sha512ExtendChip`:Chips for the SHA-512 hash function compression.
+- `Sha512CompressChip`, `Sha512ExtendChip`: Chips for the SHA-512 hash function compression.
 
 Notably, the Kadena light client does not use BLS12-381 related precompiles, such as field operations (`FieldAddChip`, `FieldSubChip`, `FieldMulChip`) or G1 decompression (`Bls12381G1DecompressChip`), neither does it use `Secp256k1DecompressChip`, a chip for decompressing K256 compressed points. Therefore, the light client’s proof does not depend on the correctness of these precompiles. 
 


### PR DESCRIPTION
- Describes in greater detail the specific changes and updates related to Sphinx, focusing especially on distinctive or significantly differing AIR chips.
- Introduces new chips for hash function compression, including `Blake2sRoundChip` for Blake2s and `Sha512CompressChip` and `Sha512ExtendChip` for SHA-512.
- Asserts notable absence of BLS12-381 related precompiles and `Secp256k1DecompressChip` in the Kadena light client.

Fixes #278