### PR TITLE
Fix typos in documentation

### DIFF
--- a/aptos/docs/src/benchmark/e2e.md
+++ b/aptos/docs/src/benchmark/e2e.md
@@ -83,7 +83,7 @@ For our [production configuration](../run/overview.md), we currently get the fol
 on `r7iz.metal-16xl` AWS EC2 instance. The sphinx's commit used
 is: [d392acc](https://github.com/argumentcomputer/sphinx/commit/d392acca56fbaa0e4dd0b73cfab0414b4e321348)
 
-## Looking for optimal Sphinx parametrs
+## Looking for optimal Sphinx parameters
 
 Sometimes it is possible to get some boost in performance on a specific benchmarking machine tuning
 `SHARD_CHUNKING_MULTIPLIER` variable. It's optimal value depends on the number of CPU cores

--- a/aptos/docs/src/benchmark/overview.md
+++ b/aptos/docs/src/benchmark/overview.md
@@ -7,7 +7,7 @@ on-chain, and represents the end-to-end time it takes to generate a proof that c
 Due to the SNARK compression, the SNARK proofs take longer to generate and require more resources.
 
 The worst case latency (described [here](../design/edge_cases.md)) can be evaluated by running the end-to-end benchmark
-for each of the two proofs, and looking at the maximum of the time it took to genereate each proof.
+for each of the two proofs, and looking at the maximum of the time it took to generate each proof.
 
 The numbers we've measured using our [production configuration](../run/overview.md) are further detailed in the 
 [E2E Benchmarks](./e2e.md) section. They are included below as well for reference:

--- a/aptos/docs/src/run/setup_proof_server.md
+++ b/aptos/docs/src/run/setup_proof_server.md
@@ -2,7 +2,7 @@
 
 > **Note**
 >
-> We will deploy the server as through the execution of the bianry with `cargo` in this example.
+> We will deploy the server as through the execution of the binary with `cargo` in this example.
 > It is also possible to deploy the proof server through its docker image. To do so, please
 > refer to [the dedicated documentation](https://github.com/argumentcomputer/zk-light-clients/tree/dev/docker).
 

--- a/ethereum/docs/src/benchmark/on_chain.md
+++ b/ethereum/docs/src/benchmark/on_chain.md
@@ -88,7 +88,7 @@ It is possible to run Move verification flow locally. This requires running Apto
 
 ## Fixture generation
 
-If you wish to run the Move script with custom fixtures, you can regeenrate them by running the
+If you wish to run the Move script with custom fixtures, you can regenerate them by running the
 `fixture-generator` Rust program. This program will run the end-to-end proving (either epoch-change or inclusion) and
 export the fixture file to the relevant place (`ethereum/move/sources/fixtures`).
 

--- a/kadena/docs/src/run/operate_bridge.md
+++ b/kadena/docs/src/run/operate_bridge.md
@@ -105,7 +105,7 @@ for different use cases.
 > The following documentation will be for SNARK proofs, as they are the only
 > proofs that can be verified on our home chains.
 
-The core data to be passed to any verification contrtact are the following:
+The core data to be passed to any verification contract are the following:
 - Verifying key: A unique key represented as 32 bytes, related to the program that is meant to be verified
 - Public values: Serialized public values of the proof
 - Proof: The serialized proof to be verified


### PR DESCRIPTION
This pull request fixes typos in the following files:

 - aptos/docs/src/benchmark/e2e.md
 - aptos/docs/src/benchmark/overview.md
 - aptos/docs/src/run/setup_proof_server.md
 - ethereum/docs/src/benchmark/on_chain.md
 - kadena/docs/src/run/operate_bridge.md

The changes include correcting spelling mistakes and improving the readability of the documentation.